### PR TITLE
feat(files/execute): add log var to improve @sasjs/adapter

### DIFF
--- a/src/controllers/Execution.ts
+++ b/src/controllers/Execution.ts
@@ -89,7 +89,6 @@ ${program}`
       (key: string) => key.toLowerCase() === '_debug'
     )
 
-    let response
     if ((debug && vars[debug] >= 131) || stderr) {
       if (!vars['_log']) {
         webout = `<html><body>
@@ -100,10 +99,8 @@ ${webout}
 </div>
 </body></html>`
       } else {
-        response = {
-          result: webout,
-          log: log
-        }
+        webout = `${webout}
+${log}`
       }
     }
 
@@ -111,6 +108,6 @@ ${webout}
 
     sessionController.deleteSession(session)
 
-    return Promise.resolve(response || webout)
+    return Promise.resolve(webout)
   }
 }

--- a/src/controllers/Execution.ts
+++ b/src/controllers/Execution.ts
@@ -89,20 +89,28 @@ ${program}`
       (key: string) => key.toLowerCase() === '_debug'
     )
 
+    let response
     if ((debug && vars[debug] >= 131) || stderr) {
-      webout = `<html><body>
+      if (!vars['_log']) {
+        webout = `<html><body>
 ${webout}
 <div style="text-align:left">
 <hr /><h2>SAS Log</h2>
 <pre>${log}</pre>
 </div>
 </body></html>`
+      } else {
+        response = {
+          result: webout,
+          log: log
+        }
+      }
     }
 
     session.inUse = false
 
     sessionController.deleteSession(session)
 
-    return Promise.resolve(webout)
+    return Promise.resolve(response || webout)
   }
 }

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -85,17 +85,14 @@ router.get('/SASjsExecutor/do', async (req, res) => {
 })
 
 router.post(
-  '/SASjsExecutor/do',
+  '/files/files/execute',
   fileUploadController.preuploadMiddleware,
   fileUploadController.getMulterUploadObject().any(),
   async (req: any, res: any) => {
-    if (isRequestQuery(req.query)) {
+    if (isRequestQuery(req.body)) {
       let sasCodePath = path
-        .join(getTmpFilesFolderPath(), req.query._program)
+        .join(getTmpFilesFolderPath(), req.body._program)
         .replace(new RegExp('/', 'g'), path.sep)
-
-      // If no extension provided, add .sas extension
-      sasCodePath += '.sas'
 
       let filesNamesMap = null
 
@@ -112,7 +109,10 @@ router.post(
           { filesNamesMap: filesNamesMap }
         )
         .then((result: {}) => {
-          res.status(200).send(result)
+          res.status(200).send({
+            status: 'success',
+            ...(typeof result === 'object' ? result : { result: result })
+          })
         })
         .catch((err: {} | string) => {
           res.status(400).send({

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -111,7 +111,7 @@ router.post(
         .then((result: {}) => {
           res.status(200).send({
             status: 'success',
-            ...(typeof result === 'object' ? result : { result: result })
+            result
           })
         })
         .catch((err: {} | string) => {


### PR DESCRIPTION
## Intent

Return `log` separately from `webout` to make parsing easier in `@sasjs/cli`.

## Implementation

- Changed `/SASjsExecutor/do` route to `/files/files/execute`
- Handled `_log` var in `ExecutionController`