### PR TITLE
fix(stp/execute): adjust responseToReturn for post method of stp/execute

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -8,7 +8,9 @@
     "start:prod": "nodemon ./src/prod-server.ts",
     "build": "rimraf build && tsc",
     "semantic-release": "semantic-release -d",
-    "prepare": "[ -d .git ] && git config core.hooksPath ./.git-hooks || true",
+    "prepare": "npm run create-tmp-dir && npm run create-web-build && [ -d .git ] && git config core.hooksPath ./.git-hooks || true",
+    "create-web-build": "cd ../web && npm install && npm run build",
+    "create-tmp-dir": "mkdir -p tmp/files",
     "test": "mkdir -p tmp && mkdir -p ../web/build && jest --coverage"
   },
   "release": {

--- a/api/package.json
+++ b/api/package.json
@@ -39,6 +39,6 @@
   },
   "configuration": {
     "sasPath": "/opt/sas/sas9/SASHome/SASFoundation/9.4/sas",
-    "sasJsPort": 5005
+    "sasJsPort": 5001
   }
 }

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -4,13 +4,15 @@ import apiRouter from './routes/api'
 import { getWebBuildFolderPath } from './utils'
 
 const app = express()
+app.use((req, res, next) => {
+  res.header('Access-Control-Allow-Origin', 'http://localhost:3000')
+  res.header('Access-Control-Allow-Credentials', 'true')
+  next()
+})
 
 app.use(express.json({ limit: '50mb' }))
-
+app.use(express.static(getWebBuildFolderPath()))
 app.use('/', webRouter)
 app.use('/SASjsApi', apiRouter)
-app.use(express.json({ limit: '50mb' }))
-
-app.use(express.static(getWebBuildFolderPath()))
 
 export default app

--- a/api/src/controllers/Execution.ts
+++ b/api/src/controllers/Execution.ts
@@ -92,24 +92,36 @@ ${program}`
       (key: string) => key.toLowerCase() === '_debug'
     )
 
-    let jsonResult
-    if ((debug && vars[debug] >= 131) || stderr) {
-      webout = `<html><body>
-${webout}
-<div style="text-align:left">
-<hr /><h2>SAS Log</h2>
-<pre>${log}</pre>
-</div>
-</body></html>`
-    } else if (returnJson) {
-      jsonResult = { result: webout, log: log }
+    let responseToReturn
+
+    if (returnJson) {
+      if (debug && vars[debug] >= 131) {
+        responseToReturn = {
+          _webout: webout,
+          log: log
+        }
+      } else {
+        responseToReturn = { _webout: webout }
+      }
+    } else {
+      if ((debug && vars[debug] >= 131) || stderr) {
+        responseToReturn = `<html><body>
+  ${webout}
+  <div style="text-align:left">
+  <hr /><h2>SAS Log</h2>
+  <pre>${log}</pre>
+  </div>
+  </body></html>`
+      } else {
+        responseToReturn = webout
+      }
     }
 
     session.inUse = false
 
     sessionController.deleteSession(session)
 
-    return Promise.resolve(jsonResult || webout)
+    return Promise.resolve(responseToReturn)
   }
 
   buildDirectorytree() {

--- a/api/src/routes/api/stp.ts
+++ b/api/src/routes/api/stp.ts
@@ -69,10 +69,7 @@ stpRouter.post(
           true
         )
         .then((result: {}) => {
-          res.status(200).send({
-            status: 'success',
-            ...result
-          })
+          res.status(200).send(result)
         })
         .catch((err: {} | string) => {
           res.status(400).send({


### PR DESCRIPTION
when post  method of stp/execute api end point is called then execution controller should return the in such a manner that when debug is off then return `responseToReturn = { _webout: webout }` else `responseToReturn = { _webout: webout, log: log }`