### PR TITLE
fix: csp updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ HELMET_COEP=
 #
 # Example config:
 # {
-#   "img-src": ["'self'", "domain.com"],
+#   "img-src": ["'self'", "data:"],
 #   "script-src": ["'self'", "'unsafe-inline'"],
 #   "script-src-attr": ["'self'", "'unsafe-inline'"]
 # }

--- a/api/csp.config.example.json
+++ b/api/csp.config.example.json
@@ -1,5 +1,5 @@
 {
-  "img-src": ["'self'", "domen.com"],
+  "img-src": ["'self'", "data:"],
   "script-src": ["'self'", "'unsafe-inline'"],
   "script-src-attr": ["'self'", "'unsafe-inline'"]
 }

--- a/api/src/utils/parseHelmetConfig.ts
+++ b/api/src/utils/parseHelmetConfig.ts
@@ -5,7 +5,7 @@ export const getEnvCSPDirectives = (
   HELMET_CSP_CONFIG_PATH: string | undefined
 ) => {
   let cspConfigJson = {
-    'img-src': ["'self'", "data:"],
+    'img-src': ["'self'", 'data:'],
     'script-src': ["'self'", "'unsafe-inline'"],
     'script-src-attr': ["'self'", "'unsafe-inline'"]
   }

--- a/api/src/utils/parseHelmetConfig.ts
+++ b/api/src/utils/parseHelmetConfig.ts
@@ -5,7 +5,9 @@ export const getEnvCSPDirectives = (
   HELMET_CSP_CONFIG_PATH: string | undefined
 ) => {
   let cspConfigJson = {
-    'script-src': ["'self'", "'unsafe-inline'"]
+    'img-src': ["'self'", "data:"],
+    'script-src': ["'self'", "'unsafe-inline'"],
+    'script-src-attr': ["'self'", "'unsafe-inline'"]
   }
 
   if (


### PR DESCRIPTION
Temporarily loosening CSP Policy to allow seamless DC deploys.

Currently DC contains the bare minimum number of frontend files, to facilitate streaming apps on SAS 9 EBI deploys (many of which have only 3 multibridge connections).  Multiple parallel file requests can also bring down a Viya 4 image (2020.2 hackathon image confirmed).

That said - inline javascript is bad as it can facilitate Cross Site Scripting (XSS) attacks.  More info here:  https://csper.io/blog/no-more-unsafe-inline

The SASjs Server build of Data Controller will be updated to eliminate the script tags and then the CSP policy will be tightened up.  Ticket to follow.