### PR TITLE
fix: removing UTF-8 options from commandline.

### DIFF
--- a/api/src/controllers/internal/Session.ts
+++ b/api/src/controllers/internal/Session.ts
@@ -99,8 +99,6 @@ ${autoExecContent}`
       session.path,
       '-AUTOEXEC',
       autoExecPath,
-      '-ENCODING',
-      'UTF-8',
       process.platform === 'win32' ? '-nosplash' : '',
       process.platform === 'win32' ? '-icon' : '',
       process.platform === 'win32' ? '-nologo' : ''


### PR DESCRIPTION
There appears to be no reliable way to enforce UTF-8 without additional modifications to the PATH variable to ensure a DBCS instance of SAS.

Closes #205 