### PR TITLE
fix: getRuntimeAndFilePath function

### DIFF
--- a/api/src/utils/getRunTimeAndFilePath.ts
+++ b/api/src/utils/getRunTimeAndFilePath.ts
@@ -5,7 +5,8 @@ import { RunTimeType } from '.'
 
 export const getRunTimeAndFilePath = async (programPath: string) => {
   const ext = path.extname(programPath)
-  // if program path is provided with extension we should split that into code path and ext as run time
+  // If programPath (_program) is provided with a ".sas" or ".js" extension 
+  // we should use that extension to determine the appropriate runTime
   if (ext && Object.values(RunTimeType).includes(ext.slice(1) as RunTimeType)) {
     const runTime = ext.slice(1)
 

--- a/api/src/utils/getRunTimeAndFilePath.ts
+++ b/api/src/utils/getRunTimeAndFilePath.ts
@@ -6,13 +6,8 @@ import { RunTimeType } from '.'
 export const getRunTimeAndFilePath = async (programPath: string) => {
   const ext = path.extname(programPath)
   // if program path is provided with extension we should split that into code path and ext as run time
-  if (ext) {
+  if (ext && Object.values(RunTimeType).includes(ext.slice(1) as RunTimeType)) {
     const runTime = ext.slice(1)
-    const runTimeTypes = Object.values(RunTimeType)
-
-    if (!runTimeTypes.includes(runTime as RunTimeType)) {
-      throw `The '${runTime}' runtime is not supported.`
-    }
 
     const codePath = path
       .join(getFilesFolder(), programPath)


### PR DESCRIPTION
## Issue

none

## Intent

* getRuntimeAndFilePath function to handle the scenario when the path is provided with an extension other than runtimes

## Implementation

* add an additional check to see if the extension belongs to `RunTimeType`

## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] Reviewer is assigned.
