### PR TITLE
fix(deploy): extract first json from zip file

### DIFF
--- a/api/src/utils/zipped.ts
+++ b/api/src/utils/zipped.ts
@@ -28,7 +28,8 @@ export const extractJSONFromZip = async (zipFile: Express.Multer.File) => {
 
   for await (const entry of zip) {
     const fileName = entry.path as string
-    if (fileName.toUpperCase().endsWith('.JSON') && fileName === fileInZip) {
+    // grab the first json found in .zip
+    if (fileName.toUpperCase().endsWith('.JSON')) {
       fileContent = await entry.buffer()
       break
     } else {


### PR DESCRIPTION
## Issue

Closes #211 

## Intent

rather than insist on a file with the same name as the zip, we should just check that the content is a single, valid, json file

## Implementation

Extracting first json file present in zip file.

## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] Reviewer is assigned.
