### PR TITLE
feat: removed secrets from env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,10 +105,6 @@ CERT_CHAIN=certificate.pem (required)
 CA_ROOT=fullchain.pem (optional)
 
 # ENV variables required for MODE: `server`
-ACCESS_TOKEN_SECRET=<secret>
-REFRESH_TOKEN_SECRET=<secret>
-AUTH_CODE_SECRET=<secret>
-SESSION_SECRET=<secret>
 DB_CONNECT=mongodb+srv://<DB_USERNAME>:<DB_PASSWORD>@<CLUSTER>/<DB_NAME>?retryWrites=true&w=majority
 
 # options: [disable|enable] default: `disable` for `server` & `enable` for `desktop`

--- a/api/.env.example
+++ b/api/.env.example
@@ -12,10 +12,6 @@ PORT=[5000] default value is 5000
 HELMET_CSP_CONFIG_PATH=./csp.config.json if omitted HELMET default will be used
 HELMET_COEP=[true|false] if omitted HELMET default will be used
 
-ACCESS_TOKEN_SECRET=<secret>
-REFRESH_TOKEN_SECRET=<secret>
-AUTH_CODE_SECRET=<secret>
-SESSION_SECRET=<secret>
 DB_CONNECT=mongodb+srv://<DB_USERNAME>:<DB_PASSWORD>@<CLUSTER>/<DB_NAME>?retryWrites=true&w=majority
 
 RUN_TIMES=[sas|js|sas,js|js,sas] default considered as sas

--- a/api/public/swagger.yaml
+++ b/api/public/swagger.yaml
@@ -47,41 +47,6 @@ components:
                 - userId
             type: object
             additionalProperties: false
-        LoginPayload:
-            properties:
-                username:
-                    type: string
-                    description: 'Username for user'
-                    example: secretuser
-                password:
-                    type: string
-                    description: 'Password for user'
-                    example: secretpassword
-            required:
-                - username
-                - password
-            type: object
-            additionalProperties: false
-        AuthorizeResponse:
-            properties:
-                code:
-                    type: string
-                    description: 'Authorization code'
-                    example: someRandomCryptoString
-            required:
-                - code
-            type: object
-            additionalProperties: false
-        AuthorizePayload:
-            properties:
-                clientId:
-                    type: string
-                    description: 'Client ID'
-                    example: clientID1
-            required:
-                - clientId
-            type: object
-            additionalProperties: false
         ClientPayload:
             properties:
                 clientId:
@@ -440,13 +405,13 @@ components:
             type: object
         Pick__LeanDocument_T_.Exclude_keyof_LeanDocument_T_.Exclude_keyofDocument._id-or-id-or-__v_-or-%24isSingleNested__:
             properties:
-                id:
-                    description: 'The string version of this documents _id.'
                 _id:
                     $ref: '#/components/schemas/_LeanDocument__LeanDocument_T__'
                     description: 'This documents _id.'
                 __v:
                     description: 'This documents __v.'
+                id:
+                    description: 'The string version of this documents _id.'
             type: object
             description: 'From T, pick a set of properties whose keys are in the union K'
         Omit__LeanDocument_this_.Exclude_keyofDocument._id-or-id-or-__v_-or-%24isSingleNested_:
@@ -486,6 +451,41 @@ components:
                     type: string
                     description: 'Location of SAS program'
                     example: /Public/somefolder/some.file
+            type: object
+            additionalProperties: false
+        LoginPayload:
+            properties:
+                username:
+                    type: string
+                    description: 'Username for user'
+                    example: secretuser
+                password:
+                    type: string
+                    description: 'Password for user'
+                    example: secretpassword
+            required:
+                - username
+                - password
+            type: object
+            additionalProperties: false
+        AuthorizeResponse:
+            properties:
+                code:
+                    type: string
+                    description: 'Authorization code'
+                    example: someRandomCryptoString
+            required:
+                - code
+            type: object
+            additionalProperties: false
+        AuthorizePayload:
+            properties:
+                clientId:
+                    type: string
+                    description: 'Client ID'
+                    example: clientID1
+            required:
+                - clientId
             type: object
             additionalProperties: false
     securitySchemes:
@@ -557,86 +557,6 @@ paths:
             security:
                 -
                     bearerAuth: []
-            parameters: []
-    /:
-        get:
-            operationId: Home
-            responses:
-                '200':
-                    description: Ok
-                    content:
-                        application/json:
-                            schema:
-                                type: string
-            summary: 'Render index.html'
-            tags:
-                - Web
-            security: []
-            parameters: []
-    /SASLogon/login:
-        post:
-            operationId: Login
-            responses:
-                '200':
-                    description: Ok
-                    content:
-                        application/json:
-                            schema:
-                                properties:
-                                    user: {properties: {displayName: {type: string}, username: {type: string}, id: {type: number, format: double}}, required: [displayName, username, id], type: object}
-                                    loggedIn: {type: boolean}
-                                required:
-                                    - user
-                                    - loggedIn
-                                type: object
-            summary: 'Accept a valid username/password'
-            tags:
-                - Web
-            security: []
-            parameters: []
-            requestBody:
-                required: true
-                content:
-                    application/json:
-                        schema:
-                            $ref: '#/components/schemas/LoginPayload'
-    /SASLogon/authorize:
-        post:
-            operationId: Authorize
-            responses:
-                '200':
-                    description: Ok
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/AuthorizeResponse'
-                            examples:
-                                'Example 1':
-                                    value: {code: someRandomCryptoString}
-            summary: 'Accept a valid username/password, plus a CLIENT_ID, and return an AUTH_CODE'
-            tags:
-                - Web
-            security: []
-            parameters: []
-            requestBody:
-                required: true
-                content:
-                    application/json:
-                        schema:
-                            $ref: '#/components/schemas/AuthorizePayload'
-    /SASLogon/logout:
-        get:
-            operationId: Logout
-            responses:
-                '200':
-                    description: Ok
-                    content:
-                        application/json:
-                            schema: {}
-            summary: 'Destroy the session stored in cookies'
-            tags:
-                - Web
-            security: []
             parameters: []
     /SASjsApi/client:
         post:
@@ -1504,6 +1424,86 @@ paths:
                     application/json:
                         schema:
                             $ref: '#/components/schemas/ExecuteReturnJsonPayload'
+    /:
+        get:
+            operationId: Home
+            responses:
+                '200':
+                    description: Ok
+                    content:
+                        application/json:
+                            schema:
+                                type: string
+            summary: 'Render index.html'
+            tags:
+                - Web
+            security: []
+            parameters: []
+    /SASLogon/login:
+        post:
+            operationId: Login
+            responses:
+                '200':
+                    description: Ok
+                    content:
+                        application/json:
+                            schema:
+                                properties:
+                                    user: {properties: {displayName: {type: string}, username: {type: string}, id: {type: number, format: double}}, required: [displayName, username, id], type: object}
+                                    loggedIn: {type: boolean}
+                                required:
+                                    - user
+                                    - loggedIn
+                                type: object
+            summary: 'Accept a valid username/password'
+            tags:
+                - Web
+            security: []
+            parameters: []
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/LoginPayload'
+    /SASLogon/authorize:
+        post:
+            operationId: Authorize
+            responses:
+                '200':
+                    description: Ok
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/AuthorizeResponse'
+                            examples:
+                                'Example 1':
+                                    value: {code: someRandomCryptoString}
+            summary: 'Accept a valid username/password, plus a CLIENT_ID, and return an AUTH_CODE'
+            tags:
+                - Web
+            security: []
+            parameters: []
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/AuthorizePayload'
+    /SASLogon/logout:
+        get:
+            operationId: Logout
+            responses:
+                '200':
+                    description: Ok
+                    content:
+                        application/json:
+                            schema: {}
+            summary: 'Destroy the session stored in cookies'
+            tags:
+                - Web
+            security: []
+            parameters: []
 servers:
     -
         url: /

--- a/api/src/controllers/auth.ts
+++ b/api/src/controllers/auth.ts
@@ -129,8 +129,8 @@ const verifyAuthCode = async (
   clientId: string,
   code: string
 ): Promise<InfoJWT | undefined> => {
-  return new Promise((resolve, reject) => {
-    jwt.verify(code, process.env.AUTH_CODE_SECRET as string, (err, data) => {
+  return new Promise((resolve) => {
+    jwt.verify(code, process.secrets.AUTH_CODE_SECRET, (err, data) => {
       if (err) return resolve(undefined)
 
       const clientInfo: InfoJWT = {

--- a/api/src/controllers/group.ts
+++ b/api/src/controllers/group.ts
@@ -20,7 +20,7 @@ export interface GroupResponse {
   description: string
 }
 
-interface GroupDetailsResponse {
+export interface GroupDetailsResponse {
   groupId: number
   name: string
   description: string
@@ -249,9 +249,10 @@ const updateUsersListInGroup = async (
       message: 'User not found.'
     }
 
-  const updatedGroup = (action === 'addUser'
-    ? await group.addUser(user._id)
-    : await group.removeUser(user._id)) as unknown as GroupDetailsResponse
+  const updatedGroup =
+    action === 'addUser'
+      ? await group.addUser(user)
+      : await group.removeUser(user)
 
   if (!updatedGroup)
     throw {
@@ -259,9 +260,6 @@ const updateUsersListInGroup = async (
       status: 'Bad Request',
       message: 'Unable to update group.'
     }
-
-  if (action === 'addUser') user.addGroup(group._id)
-  else user.removeGroup(group._id)
 
   return {
     groupId: updatedGroup.groupId,

--- a/api/src/middlewares/authenticateToken.ts
+++ b/api/src/middlewares/authenticateToken.ts
@@ -35,7 +35,7 @@ export const authenticateAccessToken: RequestHandler = async (
     req,
     res,
     next,
-    process.env.ACCESS_TOKEN_SECRET as string,
+    process.secrets.ACCESS_TOKEN_SECRET,
     'accessToken'
   )
 }
@@ -45,7 +45,7 @@ export const authenticateRefreshToken: RequestHandler = (req, res, next) => {
     req,
     res,
     next,
-    process.env.REFRESH_TOKEN_SECRET as string,
+    process.secrets.REFRESH_TOKEN_SECRET,
     'refreshToken'
   )
 }

--- a/api/src/model/Configuration.ts
+++ b/api/src/model/Configuration.ts
@@ -1,0 +1,45 @@
+import mongoose, { Schema } from 'mongoose'
+
+export interface ConfigurationType {
+  /**
+   * SecretOrPrivateKey to sign Access Token
+   * @example "someRandomCryptoString"
+   */
+  ACCESS_TOKEN_SECRET: string
+  /**
+   * SecretOrPrivateKey to sign Refresh Token
+   * @example "someRandomCryptoString"
+   */
+  REFRESH_TOKEN_SECRET: string
+  /**
+   * SecretOrPrivateKey to sign Auth Code
+   * @example "someRandomCryptoString"
+   */
+  AUTH_CODE_SECRET: string
+  /**
+   * Secret used to sign the session cookie
+   * @example "someRandomCryptoString"
+   */
+  SESSION_SECRET: string
+}
+
+const ConfigurationSchema = new Schema<ConfigurationType>({
+  ACCESS_TOKEN_SECRET: {
+    type: String,
+    required: true
+  },
+  REFRESH_TOKEN_SECRET: {
+    type: String,
+    required: true
+  },
+  AUTH_CODE_SECRET: {
+    type: String,
+    required: true
+  },
+  SESSION_SECRET: {
+    type: String,
+    required: true
+  }
+})
+
+export default mongoose.model('Configuration', ConfigurationSchema)

--- a/api/src/model/User.ts
+++ b/api/src/model/User.ts
@@ -35,6 +35,7 @@ export interface UserPayload {
 }
 
 interface IUserDocument extends UserPayload, Document {
+  _id: Schema.Types.ObjectId
   id: number
   isAdmin: boolean
   isActive: boolean
@@ -43,7 +44,7 @@ interface IUserDocument extends UserPayload, Document {
   tokens: [{ [key: string]: string }]
 }
 
-interface IUser extends IUserDocument {
+export interface IUser extends IUserDocument {
   comparePassword(password: string): boolean
   addGroup(groupObjectId: Schema.Types.ObjectId): Promise<IUser>
   removeGroup(groupObjectId: Schema.Types.ObjectId): Promise<IUser>

--- a/api/src/types/system/process.d.ts
+++ b/api/src/types/system/process.d.ts
@@ -8,5 +8,6 @@ declare namespace NodeJS {
     appStreamConfig: import('../').AppStreamConfig
     logger: import('@sasjs/utils/logger').Logger
     runTimes: import('../../utils').RunTimeType[]
+    secrets: import('../../model/Configuration').ConfigurationType
   }
 }

--- a/api/src/utils/connectDB.ts
+++ b/api/src/utils/connectDB.ts
@@ -9,7 +9,5 @@ export const connectDB = async () => {
   }
 
   console.log('Connected to DB!')
-  await seedDB()
-
-  return mongoose.connection
+  return seedDB()
 }

--- a/api/src/utils/generateAccessToken.ts
+++ b/api/src/utils/generateAccessToken.ts
@@ -2,6 +2,6 @@ import jwt from 'jsonwebtoken'
 import { InfoJWT } from '../types'
 
 export const generateAccessToken = (data: InfoJWT) =>
-  jwt.sign(data, process.env.ACCESS_TOKEN_SECRET as string, {
+  jwt.sign(data, process.secrets.ACCESS_TOKEN_SECRET, {
     expiresIn: '1day'
   })

--- a/api/src/utils/generateAuthCode.ts
+++ b/api/src/utils/generateAuthCode.ts
@@ -2,6 +2,6 @@ import jwt from 'jsonwebtoken'
 import { InfoJWT } from '../types'
 
 export const generateAuthCode = (data: InfoJWT) =>
-  jwt.sign(data, process.env.AUTH_CODE_SECRET as string, {
+  jwt.sign(data, process.secrets.AUTH_CODE_SECRET, {
     expiresIn: '30s'
   })

--- a/api/src/utils/generateRefreshToken.ts
+++ b/api/src/utils/generateRefreshToken.ts
@@ -2,6 +2,6 @@ import jwt from 'jsonwebtoken'
 import { InfoJWT } from '../types'
 
 export const generateRefreshToken = (data: InfoJWT) =>
-  jwt.sign(data, process.env.REFRESH_TOKEN_SECRET as string, {
+  jwt.sign(data, process.secrets.REFRESH_TOKEN_SECRET, {
     expiresIn: '30 days'
   })

--- a/api/src/utils/getRunTimeAndFilePath.ts
+++ b/api/src/utils/getRunTimeAndFilePath.ts
@@ -5,7 +5,7 @@ import { RunTimeType } from '.'
 
 export const getRunTimeAndFilePath = async (programPath: string) => {
   const ext = path.extname(programPath)
-  // If programPath (_program) is provided with a ".sas" or ".js" extension 
+  // If programPath (_program) is provided with a ".sas" or ".js" extension
   // we should use that extension to determine the appropriate runTime
   if (ext && Object.values(RunTimeType).includes(ext.slice(1) as RunTimeType)) {
     const runTime = ext.slice(1)

--- a/api/src/utils/seedDB.ts
+++ b/api/src/utils/seedDB.ts
@@ -1,6 +1,73 @@
 import Client from '../model/Client'
+import Group from '../model/Group'
 import User from '../model/User'
+import Configuration, { ConfigurationType } from '../model/Configuration'
 
+import { randomBytes } from 'crypto'
+
+export const SECRETS: ConfigurationType = {
+  ACCESS_TOKEN_SECRET: randomBytes(64).toString('hex'),
+  REFRESH_TOKEN_SECRET: randomBytes(64).toString('hex'),
+  AUTH_CODE_SECRET: randomBytes(64).toString('hex'),
+  SESSION_SECRET: randomBytes(64).toString('hex')
+}
+
+export const seedDB = async (): Promise<ConfigurationType> => {
+  // Checking if client is already in the database
+  const clientExist = await Client.findOne({ clientId: CLIENT.clientId })
+  if (!clientExist) {
+    const client = new Client(CLIENT)
+    await client.save()
+
+    console.log(`DB Seed - client created: ${CLIENT.clientId}`)
+  }
+
+  // Checking if 'AllUsers' Group is already in the database
+  let groupExist = await Group.findOne({ name: GROUP.name })
+  if (!groupExist) {
+    const group = new Group(GROUP)
+    groupExist = await group.save()
+
+    console.log(`DB Seed - Group created: ${GROUP.name}`)
+  }
+
+  // Checking if user is already in the database
+  let usernameExist = await User.findOne({ username: ADMIN_USER.username })
+  if (!usernameExist) {
+    const user = new User(ADMIN_USER)
+    usernameExist = await user.save()
+
+    console.log(`DB Seed - admin account created: ${ADMIN_USER.username}`)
+  }
+
+  if (!groupExist.hasUser(usernameExist)) {
+    groupExist.addUser(usernameExist)
+    console.log(
+      `DB Seed - admin account '${ADMIN_USER.username}' added to Group '${GROUP.name}'`
+    )
+  }
+
+  // checking if configuration is present in the database
+  let configExist = await Configuration.findOne()
+  if (!configExist) {
+    const configuration = new Configuration(SECRETS)
+    configExist = await configuration.save()
+
+    console.log('DB Seed - configuration added')
+  }
+
+  return {
+    ACCESS_TOKEN_SECRET: configExist.ACCESS_TOKEN_SECRET,
+    REFRESH_TOKEN_SECRET: configExist.REFRESH_TOKEN_SECRET,
+    AUTH_CODE_SECRET: configExist.AUTH_CODE_SECRET,
+    SESSION_SECRET: configExist.SESSION_SECRET
+  }
+}
+
+const GROUP = {
+  name: 'AllUsers',
+  description: 'Group contains all users'
+}
 const CLIENT = {
   clientId: 'clientID1',
   clientSecret: 'clientSecret'
@@ -12,24 +79,4 @@ const ADMIN_USER = {
   password: '$2a$10$hKvcVEZdhEQZCcxt6npazO6mY4jJkrzWvfQ5stdBZi8VTTwVMCVXO',
   isAdmin: true,
   isActive: true
-}
-
-export const seedDB = async () => {
-  // Checking if client is already in the database
-  const clientExist = await Client.findOne({ clientId: CLIENT.clientId })
-  if (!clientExist) {
-    const client = new Client(CLIENT)
-    await client.save()
-
-    console.log(`DB Seed - client created: ${CLIENT.clientId}`)
-  }
-
-  // Checking if user is already in the database
-  const usernameExist = await User.findOne({ username: ADMIN_USER.username })
-  if (!usernameExist) {
-    const user = new User(ADMIN_USER)
-    await user.save()
-
-    console.log(`DB Seed - admin account created: ${ADMIN_USER.username}`)
-  }
 }

--- a/api/src/utils/setProcessVariables.ts
+++ b/api/src/utils/setProcessVariables.ts
@@ -1,15 +1,27 @@
 import path from 'path'
 import { createFolder, getAbsolutePath, getRealPath } from '@sasjs/utils'
 
-import { getDesktopFields, ModeType, RunTimeType } from '.'
+import { connectDB, getDesktopFields, ModeType, RunTimeType, SECRETS } from '.'
 
 export const setProcessVariables = async () => {
+  const { MODE, RUN_TIMES } = process.env
+
+  if (MODE === ModeType.Server) {
+    // NOTE: when exporting app.js as agent for supertest
+    // it should prevent connecting to the real database
+    if (process.env.NODE_ENV !== 'test') {
+      const secrets = await connectDB()
+
+      process.secrets = secrets
+    } else {
+      process.secrets = SECRETS
+    }
+  }
+
   if (process.env.NODE_ENV === 'test') {
     process.driveLoc = path.join(process.cwd(), 'sasjs_root')
     return
   }
-
-  const { MODE, RUN_TIMES } = process.env
 
   process.runTimes = (RUN_TIMES?.split(',') as RunTimeType[]) ?? []
 

--- a/api/src/utils/verifyEnvVariables.ts
+++ b/api/src/utils/verifyEnvVariables.ts
@@ -78,33 +78,7 @@ const verifyMODE = (): string[] => {
   }
 
   if (process.env.MODE === ModeType.Server) {
-    const {
-      ACCESS_TOKEN_SECRET,
-      REFRESH_TOKEN_SECRET,
-      AUTH_CODE_SECRET,
-      SESSION_SECRET,
-      DB_CONNECT
-    } = process.env
-
-    if (!ACCESS_TOKEN_SECRET)
-      errors.push(
-        `- ACCESS_TOKEN_SECRET is required for PROTOCOL '${ModeType.Server}'`
-      )
-
-    if (!REFRESH_TOKEN_SECRET)
-      errors.push(
-        `- REFRESH_TOKEN_SECRET is required for PROTOCOL '${ModeType.Server}'`
-      )
-
-    if (!AUTH_CODE_SECRET)
-      errors.push(
-        `- AUTH_CODE_SECRET is required for PROTOCOL '${ModeType.Server}'`
-      )
-
-    if (!SESSION_SECRET)
-      errors.push(
-        `- SESSION_SECRET is required for PROTOCOL '${ModeType.Server}'`
-      )
+    const { DB_CONNECT } = process.env
 
     if (process.env.NODE_ENV !== 'test')
       if (!DB_CONNECT)


### PR DESCRIPTION
## Issue

Closes #213 

## Intent

All the secrets should be saved in DB, auto-generated and if already present, load them on server start.

## Implementation

Moved `ACCESS_TOKEN_SECRET`, `REFRESH_TOKEN_SECRET`, `AUTH_CODE_SECRET`, `SESSION_SECRET` from `process.env` to `process.secrets`

On startup: 
- loaded from DB
- if not present, generated and saved to DB
- then set to process.secrets

Updated `seedDB.ts` accordingly

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
- [x] All CI checks are green.
- [ ] Reviewer is assigned.
