### PR TITLE
fix: ensuring nosplash option only applies for sas.exe

### DIFF
--- a/api/src/controllers/internal/Session.ts
+++ b/api/src/controllers/internal/Session.ts
@@ -16,7 +16,6 @@ import {
   readFile,
   isWindows
 } from '@sasjs/utils'
-import { processProgram } from './processProgram'
 
 const execFilePromise = promisify(execFile)
 

--- a/api/src/controllers/internal/Session.ts
+++ b/api/src/controllers/internal/Session.ts
@@ -16,6 +16,7 @@ import {
   readFile,
   isWindows
 } from '@sasjs/utils'
+import { processProgram } from './processProgram'
 
 const execFilePromise = promisify(execFile)
 
@@ -101,7 +102,7 @@ ${autoExecContent}`
       session.path,
       '-AUTOEXEC',
       autoExecPath,
-      isWindows() ? '-nosplash' : '',
+      process.sasLoc.endsWith('sas.exe') ? '-nosplash' : '',
       isWindows() ? '-icon' : '',
       isWindows() ? '-nologo' : ''
     ])


### PR DESCRIPTION
Closes #229

## Issue

#229 

## Intent

Ensuring NOSPLASH is only applied where it is supported

## Implementation

Testing the end of the SAS_PATH string for `sas.exe`

## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] Reviewer is assigned.
