### PR TITLE
fix: filePath fix in code.js file for windows

### DIFF
--- a/api/src/controllers/internal/createJSProgram.ts
+++ b/api/src/controllers/internal/createJSProgram.ts
@@ -23,7 +23,7 @@ let _webout = '';
 const weboutPath = '${
     isWindows() ? weboutPath.replace(/\\/g, '\\\\') : weboutPath
   }'; 
-const _sasjs_tokenfile = '${tokenFile}';
+const _sasjs_tokenfile = '${isWindows() ? tokenFile.replace(/\\/g, '\\\\') : tokenFile }';
 const _sasjs_username = '${preProgramVariables?.username}';
 const _sasjs_userid = '${preProgramVariables?.userId}';
 const _sasjs_displayname = '${preProgramVariables?.displayName}';

--- a/api/src/utils/upload.ts
+++ b/api/src/utils/upload.ts
@@ -1,6 +1,6 @@
 import path from 'path'
 import { MulterFile } from '../types/Upload'
-import { listFilesInFolder, readFileBinary } from '@sasjs/utils'
+import { listFilesInFolder, readFileBinary, isWindows } from '@sasjs/utils'
 
 interface FilenameMapSingle {
   fieldName: string
@@ -118,7 +118,7 @@ export const generateFileUploadJSCode = async (
     if (fileName.includes('req_file')) {
       fileCount++
       const filePath = path.join(sessionFolder, fileName)
-      uploadCode += `\nconst _WEBIN_FILEREF${fileCount} = fs.readFileSync('${filePath}')`
+      uploadCode += `\nconst _WEBIN_FILEREF${fileCount} = fs.readFileSync('${isWindows() ? filePath.replace(/\\/g, '\\\\') :  filePath}')`
       uploadCode += `\nconst _WEBIN_FILENAME${fileCount} = '${filesNamesMap[fileName].originalName}'`
       uploadCode += `\nconst _WEBIN_NAME${fileCount} = '${filesNamesMap[fileName].fieldName}'`
     }


### PR DESCRIPTION
## Issue

closes #227 

## Intent

* filePath fix in code.js file for windows

## Implementation

* checked `isWindows()` then replace `\\` with `\\\\` in filePath

## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] Reviewer is assigned.
