### PR TITLE
fix(cookie): XSRF cookie is removed and passed token in head section

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -1,6 +1,6 @@
 import path from 'path'
 import express, { ErrorRequestHandler } from 'express'
-import csrf from 'csurf'
+import csrf, { CookieOptions } from 'csurf'
 import cookieParser from 'cookie-parser'
 import dotenv from 'dotenv'
 
@@ -32,9 +32,10 @@ const app = express()
 
 const { PROTOCOL } = process.env
 
-export const cookieOptions = {
+export const cookieOptions: CookieOptions = {
   secure: PROTOCOL === ProtocolType.HTTPS,
   httpOnly: true,
+  sameSite: PROTOCOL === ProtocolType.HTTPS ? 'none' : undefined,
   maxAge: 24 * 60 * 60 * 1000 // 24 hours
 }
 

--- a/api/src/routes/appStream/style.ts
+++ b/api/src/routes/appStream/style.ts
@@ -26,6 +26,7 @@ export const style = `<style>
 }
 .app-container .app img{
   width: 100%;
+  height: calc(100% - 30px);
   margin-bottom: 10px;
   border-radius: 10px;
 }

--- a/api/src/routes/web/web.ts
+++ b/api/src/routes/web/web.ts
@@ -11,11 +11,15 @@ webRouter.get('/', async (req, res) => {
   try {
     response = await controller.home()
   } catch (_) {
-    response = 'Web Build is not present'
+    response = '<html><head></head><body>Web Build is not present</body></html>'
   } finally {
-    res.cookie('XSRF-TOKEN', req.csrfToken())
+    const codeToInject = `<script>document.cookie = 'XSRF-TOKEN=${req.csrfToken()}; Max-Age=86400; SameSite=Strict; Path=/;'</script>`
+    const injectedContent = response?.replace(
+      '</head>',
+      `${codeToInject}</head>`
+    )
 
-    return res.send(response)
+    return res.send(injectedContent)
   }
 })
 

--- a/api/src/utils/verifyEnvVariables.ts
+++ b/api/src/utils/verifyEnvVariables.ts
@@ -125,8 +125,27 @@ const verifyCORS = (): string[] => {
 
   if (CORS) {
     const corsTypes = Object.values(CorsType)
+
     if (!corsTypes.includes(CORS as CorsType))
       errors.push(`- CORS '${CORS}'\n - valid options ${corsTypes}`)
+
+    if (CORS === CorsType.ENABLED) {
+      const { WHITELIST } = process.env
+
+      const urls = WHITELIST?.trim()
+        .split(' ')
+        .filter((url) => !!url)
+      if (urls?.length) {
+        urls.forEach((url) => {
+          if (!url.startsWith('http://') && !url.startsWith('https://'))
+            errors.push(
+              `- CORS '${CORS}'\n - provided WHITELIST ${url} is not valid`
+            )
+        })
+      } else {
+        errors.push(`- CORS '${CORS}'\n - provide at least one WHITELIST URL`)
+      }
+    }
   } else {
     const { MODE } = process.env
     process.env.CORS =

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -22,7 +22,7 @@ function App() {
         <HashRouter>
           <Header />
           <Routes>
-            <Route path="/" element={<Login />} />
+            <Route path="*" element={<Login />} />
           </Routes>
         </HashRouter>
       </ThemeProvider>

--- a/web/src/context/appContext.tsx
+++ b/web/src/context/appContext.tsx
@@ -86,7 +86,7 @@ const AppContextProvider = (props: { children: ReactNode }) => {
           .then((res) => res.data)
           .then((data: string) => {
             const result =
-              /<script>document.cookie = '(XSRF-TOKEN=[A-Za-z-0-9; =/]*)'<\/script>/.exec(
+              /<script>document.cookie = '(XSRF-TOKEN=.*; Max-Age=86400; SameSite=Strict; Path=\/;)'<\/script>/.exec(
                 data
               )?.[1]
 

--- a/web/src/context/appContext.tsx
+++ b/web/src/context/appContext.tsx
@@ -80,7 +80,18 @@ const AppContextProvider = (props: { children: ReactNode }) => {
       })
       .catch(() => {
         setLoggedIn(false)
-        axios.get('/') // get CSRF TOKEN
+        // get CSRF TOKEN and set cookie
+        axios
+          .get('/')
+          .then((res) => res.data)
+          .then((data: string) => {
+            const result =
+              /<script>document.cookie = '(XSRF-TOKEN=[A-Za-z-0-9; =/]*)'<\/script>/.exec(
+                data
+              )?.[1]
+
+            if (result) document.cookie = result
+          })
       })
 
     axios


### PR DESCRIPTION
## Issue

Applications needs to be authenticated with API server on different domain.
And fixes #125, #242 

## Intent

Cookie based authentication should work along CSRF protection.

## Implementation

Instead of sending CSRF Token from server via cookie, now it will be provided in head section.
Any request which was meant to get CSRF token, should process response extract CSRF token and save in cookie involves

- [x] Web component of sasjs/server if running on another domain
- [x] Adapter flow should also be updated, [code section](https://github.com/sasjs/adapter/blob/master/src/auth/AuthManager.ts#L228)
- [ ] Same change is required for SAS side [N/A]

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
- [x] All CI checks are green.
- [ ] Reviewer is assigned.
