### PR TITLE
fix: adding proc printto in precode to enable print output in log.  Closes #253

### DIFF
--- a/api/src/controllers/internal/createSASProgram.ts
+++ b/api/src/controllers/internal/createSASProgram.ts
@@ -34,6 +34,9 @@ export const createSASProgram = async (
 %if "&SYSTCPIPHOSTNAME"="" %then %let SYSTCPIPHOSTNAME=&_sasjs_apiserverurl;
 %mend;
 %_sasjs_server_init()
+
+proc printto print="%sysfunc(getoption(log))";
+run;
 `
 
   program = `


### PR DESCRIPTION
## Issue

#253

## Intent

Enable proc print output

## Implementation

Added the following SAS code at the start of each invocation:

```sas
proc printto print="%sysfunc(getoption(log))";
run;
```

## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] Reviewer is assigned.
