### PR TITLE
fix: update response of /SASjsApi/stp/execute and /SASjsApi/code/execute

### DIFF
--- a/api/src/routes/api/stp.ts
+++ b/api/src/routes/api/stp.ts
@@ -13,7 +13,7 @@ stpRouter.get('/execute', async (req, res) => {
   if (error) return res.status(400).send(error.details[0].message)
 
   try {
-    const response = await controller.executeReturnRaw(req, query._program)
+    const response = await controller.executeGetRequest(req, query._program)
 
     if (response instanceof Buffer) {
       res.writeHead(200, (req as any).sasHeaders)
@@ -42,7 +42,7 @@ stpRouter.post(
     // if (errQ && errB) return res.status(400).send(errB.details[0].message)
 
     try {
-      const response = await controller.executeReturnJson(
+      const response = await controller.executePostRequest(
         req,
         req.body,
         req.query?._program as string

--- a/api/src/types/system/process.d.ts
+++ b/api/src/types/system/process.d.ts
@@ -5,6 +5,7 @@ declare namespace NodeJS {
     pythonLoc?: string
     driveLoc: string
     logsLoc: string
+    logsUUID: string
     sasSessionController?: import('../../controllers/internal').SASSessionController
     jsSessionController?: import('../../controllers/internal').JSSessionController
     pythonSessionController?: import('../../controllers/internal').PythonSessionController

--- a/api/src/utils/setProcessVariables.ts
+++ b/api/src/utils/setProcessVariables.ts
@@ -50,6 +50,8 @@ export const setProcessVariables = async () => {
   await createFolder(absLogsPath)
   process.logsLoc = getRealPath(absLogsPath)
 
+  process.logsUUID = 'SASJS_LOGS_SEPARATOR_163ee17b6ff24f028928972d80a26784'
+
   console.log('sasLoc: ', process.sasLoc)
   console.log('sasDrive: ', process.driveLoc)
   console.log('sasLogs: ', process.logsLoc)

--- a/web/src/containers/Studio/editor.tsx
+++ b/web/src/containers/Studio/editor.tsx
@@ -70,6 +70,8 @@ type SASjsEditorProps = {
 }
 
 const baseUrl = window.location.origin
+const SASJS_LOGS_SEPARATOR =
+  'SASJS_LOGS_SEPARATOR_163ee17b6ff24f028928972d80a26784'
 
 const SASjsEditor = ({
   selectedFilePath,
@@ -203,13 +205,8 @@ const SASjsEditor = ({
     axios
       .post(`/SASjsApi/code/execute`, { code, runTime: selectedRunTime })
       .then((res: any) => {
-        const parsedLog = res?.data?.log
-          .map((logLine: any) => logLine.line)
-          .join('\n')
-
-        setLog(parsedLog)
-
-        setWebout(`${res.data?._webout}`)
+        setWebout(res.data.split(SASJS_LOGS_SEPARATOR)[0] ?? '')
+        setLog(res.data.split(SASJS_LOGS_SEPARATOR)[1] ?? '')
         setTab('log')
 
         // Scroll to bottom of log


### PR DESCRIPTION
## Issue

closes #258

## Intent

* Send back the raw value of webout.txt directly in the response
* Append the log if DEBUG >0 or if the executable returned a non-0 response
* Use a separator to distinguish the two in the response

## Implementation

* modified stp controller to handle the updated response from execution controller
* modified code controller to handle the updated response from execution controller
* add new process variable: `process.logsUUID = 'SASJS_LOGS_SEPARATOR_163ee17b6ff24f028928972d80a26784'`

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [x] All CI checks are green.
- [ ] Reviewer is assigned.
