### PR TITLE
fix: addition of SASINITIALFOLDER startup option.  Closes #260

### DIFF
--- a/api/src/controllers/internal/Session.ts
+++ b/api/src/controllers/internal/Session.ts
@@ -101,6 +101,8 @@ ${autoExecContent}`
       session.path,
       '-AUTOEXEC',
       autoExecPath,
+      '-SASINITIALFOLDER',
+      session.path,
       process.sasLoc!.endsWith('sas.exe') ? '-nosplash' : '',
       process.sasLoc!.endsWith('sas.exe') ? '-icon' : '',
       process.sasLoc!.endsWith('sas.exe') ? '-nodms' : '',


### PR DESCRIPTION
## Issue

#260 

## Intent

Initial SAS folder should be the session folder, similar to Python and JS Stored Programs.

## Implementation

Used SASINITIALFOLDER startup option.

## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] Reviewer is assigned.
