### PR TITLE
feat: add the functionality of saving file by ctrl + s in editor

### DIFF
--- a/web/src/components/filePathInputModal.tsx
+++ b/web/src/components/filePathInputModal.tsx
@@ -23,7 +23,7 @@ const FilePathInputModal = ({
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const value = event.target.value
 
-    const specialChars = /[`!@#$%^&*()_+\-=[\]{};':"\\|,<>?~]/
+    const specialChars = /[`!@#$%^&*()+\-=[\]{};':"\\|,<>?~]/
     const fileExtension = /\.(exe|sh|htaccess)$/i
 
     if (specialChars.test(value)) {

--- a/web/src/components/nameInputModal.tsx
+++ b/web/src/components/nameInputModal.tsx
@@ -44,7 +44,7 @@ const NameInputModal = ({
     const value = event.target.value
 
     const folderNameRegex = /[`!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?~]/
-    const fileNameRegex = /[`!@#$%^&*()_+\-=[\]{};':"\\|,<>/?~]/
+    const fileNameRegex = /[`!@#$%^&*()+\-=[\]{};':"\\|,<>/?~]/
     const fileNameExtensionRegex = /.(exe|sh|htaccess)$/i
 
     const specialChars = isFolder ? folderNameRegex : fileNameRegex


### PR DESCRIPTION
## Issue
closes #256 

## Intent
* allow underscores in file names
* when no file is selected `ctrl + s` should open a file name input modal
* when a file is selected and prev file content is not equal to current file content, `ctrl + s` should save updated file

## Implementation

* add an action to editor instance

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
- [x] All CI checks are green.
- [ ] Reviewer is assigned.
