### PR TITLE
fix: typo mistake

### DIFF
--- a/api/src/utils/getDesktopFields.ts
+++ b/api/src/utils/getDesktopFields.ts
@@ -16,7 +16,7 @@ export const getDesktopFields = async () => {
     nodeLoc = NODE_PATH ?? (await getNodeLocation())
   }
 
-  if (process.runTimes.includes(RunTimeType.JS)) {
+  if (process.runTimes.includes(RunTimeType.PY)) {
     pythonLoc = PYTHON_PATH ?? (await getPythonLocation())
   }
 


### PR DESCRIPTION
## Issue

closes #265

## Intent

* If python is not set as a runtime, it should not ask for PYTHON_PATH on launch

## Implementation

* it was a typo mistake, should have `PY` instead of `JS`

## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] Reviewer is assigned.
