### PR TITLE
fix: making SASINITIALFOLDER option windows only.  Closes #267

### DIFF
--- a/api/src/controllers/internal/Session.ts
+++ b/api/src/controllers/internal/Session.ts
@@ -101,13 +101,12 @@ ${autoExecContent}`
       session.path,
       '-AUTOEXEC',
       autoExecPath,
-      '-SASINITIALFOLDER',
-      session.path,
       process.sasLoc!.endsWith('sas.exe') ? '-nosplash' : '',
       process.sasLoc!.endsWith('sas.exe') ? '-icon' : '',
       process.sasLoc!.endsWith('sas.exe') ? '-nodms' : '',
       process.sasLoc!.endsWith('sas.exe') ? '-noterminal' : '',
       process.sasLoc!.endsWith('sas.exe') ? '-nostatuswin' : '',
+      process.sasLoc!.endsWith('sas.exe') ? '-SASINITIALFOLDER' : session.path,
       isWindows() ? '-nologo' : ''
     ])
       .then(() => {


### PR DESCRIPTION
## Issue

#267 

## Intent

Make SASINITIALFOLDER windows only

## Implementation

Test to see if SAS executable ends with ".exe" and if so, use the option

## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] Reviewer is assigned.
