### PR TITLE
fix: SASINITIALFOLDER split over 2 params, closes #271

### DIFF
--- a/api/src/controllers/internal/Session.ts
+++ b/api/src/controllers/internal/Session.ts
@@ -101,15 +101,14 @@ ${autoExecContent}`
       session.path,
       '-AUTOEXEC',
       autoExecPath,
+      isWindows() ? '-nologo' : '',
       process.sasLoc!.endsWith('sas.exe') ? '-nosplash' : '',
       process.sasLoc!.endsWith('sas.exe') ? '-icon' : '',
       process.sasLoc!.endsWith('sas.exe') ? '-nodms' : '',
       process.sasLoc!.endsWith('sas.exe') ? '-noterminal' : '',
       process.sasLoc!.endsWith('sas.exe') ? '-nostatuswin' : '',
-      process.sasLoc!.endsWith('sas.exe')
-        ? '-SASINITIALFOLDER ' + session.path
-        : '',
-      isWindows() ? '-nologo' : ''
+      process.sasLoc!.endsWith('sas.exe') ? '-SASINITIALFOLDER' : '',
+      process.sasLoc!.endsWith('sas.exe') ? session.path : ''
     ])
       .then(() => {
         session.completed = true


### PR DESCRIPTION
## Issue

#271 

## Intent

Fix missing param value

## Implementation

split params over 2 entries

## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] Reviewer is assigned.
