### PR TITLE
fix: SASJS_WEBOUT_HEADERS path for windows

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.2",
       "dependencies": {
         "@sasjs/core": "^4.31.3",
-        "@sasjs/utils": "2.42.1",
+        "@sasjs/utils": "2.48.1",
         "bcryptjs": "^2.4.3",
         "connect-mongo": "^4.6.0",
         "cookie-parser": "^1.4.6",
@@ -1396,9 +1396,9 @@
       "integrity": "sha512-TpVqWl5bqp3JTQjIg0r4WiQg7Ima5f17eAJILJbdYDdXsnLXlA/Csbb95G7eDPhzWpM3C0NrzKek3yvCMGzXIA=="
     },
     "node_modules/@sasjs/utils": {
-      "version": "2.42.1",
-      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.42.1.tgz",
-      "integrity": "sha512-DzHNYjeoj2eUkwV7Sa4eHCKRoTrYaQ6eyv6c1U5qOYXwVdZpMoYA3HFsHj55UcMOn2U3CXI5nrR7PZlUmVwVbQ==",
+      "version": "2.48.1",
+      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.48.1.tgz",
+      "integrity": "sha512-Eu9p66JKLeTj0KK3kfY7YLQYq+MDMS1Q1/FOFfRe9hV23mFsuzierVMrnEYGK0JaHOogdHLmwzg6iVLDT8Jssg==",
       "hasInstallScript": true,
       "dependencies": {
         "@types/fs-extra": "9.0.13",
@@ -10974,9 +10974,9 @@
       "integrity": "sha512-TpVqWl5bqp3JTQjIg0r4WiQg7Ima5f17eAJILJbdYDdXsnLXlA/Csbb95G7eDPhzWpM3C0NrzKek3yvCMGzXIA=="
     },
     "@sasjs/utils": {
-      "version": "2.42.1",
-      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.42.1.tgz",
-      "integrity": "sha512-DzHNYjeoj2eUkwV7Sa4eHCKRoTrYaQ6eyv6c1U5qOYXwVdZpMoYA3HFsHj55UcMOn2U3CXI5nrR7PZlUmVwVbQ==",
+      "version": "2.48.1",
+      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.48.1.tgz",
+      "integrity": "sha512-Eu9p66JKLeTj0KK3kfY7YLQYq+MDMS1Q1/FOFfRe9hV23mFsuzierVMrnEYGK0JaHOogdHLmwzg6iVLDT8Jssg==",
       "requires": {
         "@types/fs-extra": "9.0.13",
         "@types/prompts": "2.0.13",

--- a/api/package.json
+++ b/api/package.json
@@ -48,7 +48,7 @@
   "author": "4GL Ltd",
   "dependencies": {
     "@sasjs/core": "^4.31.3",
-    "@sasjs/utils": "2.42.1",
+    "@sasjs/utils": "2.48.1",
     "bcryptjs": "^2.4.3",
     "connect-mongo": "^4.6.0",
     "cookie-parser": "^1.4.6",

--- a/api/src/controllers/internal/createJSProgram.ts
+++ b/api/src/controllers/internal/createJSProgram.ts
@@ -1,4 +1,4 @@
-import { isWindows } from '@sasjs/utils'
+import { escapeWinSlashes } from '@sasjs/utils'
 import { PreProgramVars, Session } from '../../types'
 import { generateFileUploadJSCode } from '../../utils'
 import { ExecutionVars } from './'
@@ -21,15 +21,9 @@ export const createJSProgram = async (
 
   const preProgramVarStatments = `
 let _webout = '';
-const weboutPath = '${
-    isWindows() ? weboutPath.replace(/\\/g, '\\\\') : weboutPath
-  }'; 
-const _SASJS_TOKENFILE = '${
-    isWindows() ? tokenFile.replace(/\\/g, '\\\\') : tokenFile
-  }';
-const _SASJS_WEBOUT_HEADERS = '${
-    isWindows() ? headersPath.replace(/\\/g, '\\\\') : headersPath
-  }';
+const weboutPath = '${escapeWinSlashes(weboutPath)}'; 
+const _SASJS_TOKENFILE = '${escapeWinSlashes(tokenFile)}';
+const _SASJS_WEBOUT_HEADERS = '${escapeWinSlashes(headersPath)}';
 const _SASJS_USERNAME = '${preProgramVariables?.username}';
 const _SASJS_USERID = '${preProgramVariables?.userId}';
 const _SASJS_DISPLAYNAME = '${preProgramVariables?.displayName}';

--- a/api/src/controllers/internal/createJSProgram.ts
+++ b/api/src/controllers/internal/createJSProgram.ts
@@ -27,7 +27,9 @@ const weboutPath = '${
 const _SASJS_TOKENFILE = '${
     isWindows() ? tokenFile.replace(/\\/g, '\\\\') : tokenFile
   }';
-const _SASJS_WEBOUT_HEADERS = '${headersPath}';
+const _SASJS_WEBOUT_HEADERS = '${
+    isWindows() ? headersPath.replace(/\\/g, '\\\\') : headersPath
+  }';
 const _SASJS_USERNAME = '${preProgramVariables?.username}';
 const _SASJS_USERID = '${preProgramVariables?.userId}';
 const _SASJS_DISPLAYNAME = '${preProgramVariables?.displayName}';

--- a/api/src/controllers/internal/createPythonProgram.ts
+++ b/api/src/controllers/internal/createPythonProgram.ts
@@ -23,7 +23,9 @@ _SASJS_SESSION_PATH = '${
     isWindows() ? session.path.replace(/\\/g, '\\\\') : session.path
   }';
 _WEBOUT = '${isWindows() ? weboutPath.replace(/\\/g, '\\\\') : weboutPath}'; 
-_SASJS_WEBOUT_HEADERS = '${headersPath}';
+_SASJS_WEBOUT_HEADERS = '${
+    isWindows() ? headersPath.replace(/\\/g, '\\\\') : headersPath
+  }';
 _SASJS_TOKENFILE = '${
     isWindows() ? tokenFile.replace(/\\/g, '\\\\') : tokenFile
   }';

--- a/api/src/controllers/internal/createPythonProgram.ts
+++ b/api/src/controllers/internal/createPythonProgram.ts
@@ -1,4 +1,4 @@
-import { isWindows } from '@sasjs/utils'
+import { escapeWinSlashes } from '@sasjs/utils'
 import { PreProgramVars, Session } from '../../types'
 import { generateFileUploadPythonCode } from '../../utils'
 import { ExecutionVars } from './'
@@ -19,16 +19,10 @@ export const createPythonProgram = async (
   )
 
   const preProgramVarStatments = `
-_SASJS_SESSION_PATH = '${
-    isWindows() ? session.path.replace(/\\/g, '\\\\') : session.path
-  }';
-_WEBOUT = '${isWindows() ? weboutPath.replace(/\\/g, '\\\\') : weboutPath}'; 
-_SASJS_WEBOUT_HEADERS = '${
-    isWindows() ? headersPath.replace(/\\/g, '\\\\') : headersPath
-  }';
-_SASJS_TOKENFILE = '${
-    isWindows() ? tokenFile.replace(/\\/g, '\\\\') : tokenFile
-  }';
+_SASJS_SESSION_PATH = '${escapeWinSlashes(session.path)}';
+_WEBOUT = '${escapeWinSlashes(weboutPath)}'; 
+_SASJS_WEBOUT_HEADERS = '${escapeWinSlashes(headersPath)}';
+_SASJS_TOKENFILE = '${escapeWinSlashes(tokenFile)}';
 _SASJS_USERNAME = '${preProgramVariables?.username}';
 _SASJS_USERID = '${preProgramVariables?.userId}';
 _SASJS_DISPLAYNAME = '${preProgramVariables?.displayName}';

--- a/api/src/controllers/internal/createRProgram.ts
+++ b/api/src/controllers/internal/createRProgram.ts
@@ -1,4 +1,4 @@
-import { isWindows } from '@sasjs/utils'
+import { escapeWinSlashes } from '@sasjs/utils'
 import { PreProgramVars, Session } from '../../types'
 import { generateFileUploadRCode } from '../../utils'
 import { ExecutionVars } from '.'
@@ -19,16 +19,10 @@ export const createRProgram = async (
   )
 
   const preProgramVarStatments = `
-._SASJS_SESSION_PATH <- '${
-    isWindows() ? session.path.replace(/\\/g, '\\\\') : session.path
-  }';
-._WEBOUT <- '${isWindows() ? weboutPath.replace(/\\/g, '\\\\') : weboutPath}'; 
-._SASJS_WEBOUT_HEADERS <- '${
-    isWindows() ? headersPath.replace(/\\/g, '\\\\') : headersPath
-  }';
-._SASJS_TOKENFILE <- '${
-    isWindows() ? tokenFile.replace(/\\/g, '\\\\') : tokenFile
-  }';
+._SASJS_SESSION_PATH <- '${escapeWinSlashes(session.path)}';
+._WEBOUT <- '${escapeWinSlashes(weboutPath)}'; 
+._SASJS_WEBOUT_HEADERS <- '${escapeWinSlashes(headersPath)}';
+._SASJS_TOKENFILE <- '${escapeWinSlashes(tokenFile)}';
 ._SASJS_USERNAME <- '${preProgramVariables?.username}';
 ._SASJS_USERID <- '${preProgramVariables?.userId}';
 ._SASJS_DISPLAYNAME <- '${preProgramVariables?.displayName}';

--- a/api/src/controllers/internal/createRProgram.ts
+++ b/api/src/controllers/internal/createRProgram.ts
@@ -23,7 +23,9 @@ export const createRProgram = async (
     isWindows() ? session.path.replace(/\\/g, '\\\\') : session.path
   }';
 ._WEBOUT <- '${isWindows() ? weboutPath.replace(/\\/g, '\\\\') : weboutPath}'; 
-._SASJS_WEBOUT_HEADERS <- '${headersPath}';
+._SASJS_WEBOUT_HEADERS <- '${
+    isWindows() ? headersPath.replace(/\\/g, '\\\\') : headersPath
+  }';
 ._SASJS_TOKENFILE <- '${
     isWindows() ? tokenFile.replace(/\\/g, '\\\\') : tokenFile
   }';

--- a/api/src/controllers/internal/createSASProgram.ts
+++ b/api/src/controllers/internal/createSASProgram.ts
@@ -1,3 +1,4 @@
+import { escapeWinSlashes } from '@sasjs/utils'
 import { PreProgramVars, Session } from '../../types'
 import { generateFileUploadSasCode, getMacrosFolder } from '../../utils'
 import { ExecutionVars } from './'
@@ -8,6 +9,7 @@ export const createSASProgram = async (
   vars: ExecutionVars,
   session: Session,
   weboutPath: string,
+  headersPath: string,
   tokenFile: string,
   otherArgs?: any
 ) => {
@@ -23,7 +25,7 @@ export const createSASProgram = async (
 %let _sasjs_displayname=${preProgramVariables?.displayName};
 %let _sasjs_apiserverurl=${preProgramVariables?.serverUrl};
 %let _sasjs_apipath=/SASjsApi/stp/execute;
-%let _sasjs_webout_headers=%sysfunc(pathname(work))/../stpsrv_header.txt;
+%let _sasjs_webout_headers=${escapeWinSlashes(headersPath)};
 %let _metaperson=&_sasjs_displayname;
 %let _metauser=&_sasjs_username;
 

--- a/api/src/controllers/internal/createSASProgram.ts
+++ b/api/src/controllers/internal/createSASProgram.ts
@@ -1,4 +1,3 @@
-import { escapeWinSlashes } from '@sasjs/utils'
 import { PreProgramVars, Session } from '../../types'
 import { generateFileUploadSasCode, getMacrosFolder } from '../../utils'
 import { ExecutionVars } from './'
@@ -25,7 +24,7 @@ export const createSASProgram = async (
 %let _sasjs_displayname=${preProgramVariables?.displayName};
 %let _sasjs_apiserverurl=${preProgramVariables?.serverUrl};
 %let _sasjs_apipath=/SASjsApi/stp/execute;
-%let _sasjs_webout_headers=${escapeWinSlashes(headersPath)};
+%let _sasjs_webout_headers=${headersPath};
 %let _metaperson=&_sasjs_displayname;
 %let _metauser=&_sasjs_username;
 

--- a/api/src/controllers/internal/processProgram.ts
+++ b/api/src/controllers/internal/processProgram.ts
@@ -32,6 +32,7 @@ export const processProgram = async (
       vars,
       session,
       weboutPath,
+      headersPath,
       tokenFile,
       otherArgs
     )


### PR DESCRIPTION
## Issue

closes #281

## Intent

* variable `SASJS_WEBOUT_HEADERS` should have double backslash instead of single in case of windows


## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
- [x] All CI checks are green.
- [ ] Reviewer is assigned.
