### PR TITLE
fix: default content-type for sas programs should be text/plain

### DIFF
--- a/api/src/controllers/internal/Session.ts
+++ b/api/src/controllers/internal/Session.ts
@@ -92,6 +92,9 @@ export class SASSessionController extends SessionController {
       path: sessionFolder
     }
 
+    const headersPath = path.join(session.path, 'stpsrv_header.txt')
+    await createFile(headersPath, 'Content-type: text/plain')
+
     // we do not want to leave sessions running forever
     // we clean them up after a predefined period, if unused
     this.scheduleSessionDestroy(session)
@@ -170,7 +173,7 @@ ${autoExecContent}`
     session.ready = true
   }
 
-  public async deleteSession(session: Session) {
+  private async deleteSession(session: Session) {
     // remove the temporary files, to avoid buildup
     await deleteFolder(session.path)
 


### PR DESCRIPTION
## Intent

* default content-type for sas session should be `text/plain`

## Implementation

* create a headers file at the time of session creation for sas runtime.

## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] Reviewer is assigned.
