### PR TITLE
fix: removing single quotes from _program value

### DIFF
--- a/web/src/containers/Studio/internal/helper.ts
+++ b/web/src/containers/Studio/internal/helper.ts
@@ -31,7 +31,7 @@ export const programPathInjection = (
       return `._PROGRAM = '${path}';\n${code}`
     }
     if (runtime === RunTimeType.SAS) {
-      return `%let _program = '${path}';\n${code}`
+      return `%let _program = ${path};\n${code}`
     }
   }
 


### PR DESCRIPTION
## Issue

n/a

## Intent

Removing single quotes from mac var value (_program)

## Implementation

Removed 2 single quotes

## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] Reviewer is assigned.
