### PR TITLE
fix: made files extensions case insensitive

### DIFF
--- a/api/src/utils/getRunTimeAndFilePath.ts
+++ b/api/src/utils/getRunTimeAndFilePath.ts
@@ -4,7 +4,7 @@ import { getFilesFolder } from './file'
 import { RunTimeType } from '.'
 
 export const getRunTimeAndFilePath = async (programPath: string) => {
-  const ext = path.extname(programPath)
+  const ext = path.extname(programPath).toLowerCase()
   // If programPath (_program) is provided with a ".sas", ".js", ".py" or ".r" extension
   // we should use that extension to determine the appropriate runTime
   if (ext && Object.values(RunTimeType).includes(ext.slice(1) as RunTimeType)) {

--- a/web/src/containers/Studio/internal/hooks/useEditor.ts
+++ b/web/src/containers/Studio/internal/hooks/useEditor.ts
@@ -236,7 +236,9 @@ const useEditor = ({
   useEffect(() => {
     if (selectedFilePath) {
       setIsLoading(true)
-      setSelectedFileExtension(selectedFilePath.split('.').pop() ?? '')
+      setSelectedFileExtension(
+        selectedFilePath.split('.').pop()?.toLowerCase() ?? ''
+      )
       axios
         .get(`/SASjsApi/drive/file?_filePath=${selectedFilePath}`)
         .then((res: any) => {
@@ -270,8 +272,8 @@ const useEditor = ({
   }, [fileContent, selectedFilePath])
 
   useEffect(() => {
-    if (runTimes.includes(selectedFileExtension))
-      setSelectedRunTime(selectedFileExtension)
+    const fileExtension = selectedFileExtension.toLowerCase()
+    if (runTimes.includes(fileExtension)) setSelectedRunTime(fileExtension)
   }, [selectedFileExtension, runTimes])
 
   return {


### PR DESCRIPTION
## Issue

closes #288 

## Intent

* make file extensions case insensitive in studio

## Implementation

* convert provided file extension to lower case and then check against available runtimes

## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] Reviewer is assigned.
