### PR TITLE
fix: added domain for session cookies

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -1,5 +1,6 @@
 MODE=[desktop|server] default considered as desktop
 CORS=[disable|enable] default considered as disable for server MODE & enable for desktop MODE
+ALLOWED_DOMAIN=<just domain e.g. example.com >
 WHITELIST=<space separated urls, each starting with protocol `http` or `https`>
 
 PROTOCOL=[http|https] default considered as http

--- a/api/src/app-modules/configureExpressSession.ts
+++ b/api/src/app-modules/configureExpressSession.ts
@@ -1,10 +1,9 @@
-import { Express } from 'express'
+import { Express, CookieOptions } from 'express'
 import mongoose from 'mongoose'
 import session from 'express-session'
 import MongoStore from 'connect-mongo'
 
-import { ModeType } from '../utils'
-import { cookieOptions } from '../app'
+import { ModeType, ProtocolType } from '../utils'
 
 export const configureExpressSession = (app: Express) => {
   const { MODE } = process.env
@@ -17,6 +16,15 @@ export const configureExpressSession = (app: Express) => {
         client: mongoose.connection!.getClient() as any,
         collectionName: 'sessions'
       })
+    }
+
+    const { PROTOCOL, ALLOWED_DOMAIN } = process.env
+    const cookieOptions: CookieOptions = {
+      secure: PROTOCOL === ProtocolType.HTTPS,
+      httpOnly: true,
+      sameSite: PROTOCOL === ProtocolType.HTTPS ? 'none' : undefined,
+      maxAge: 24 * 60 * 60 * 1000, // 24 hours
+      domain: ALLOWED_DOMAIN?.trim() || undefined
     }
 
     app.use(

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -1,5 +1,5 @@
 import path from 'path'
-import express, { ErrorRequestHandler, CookieOptions } from 'express'
+import express, { ErrorRequestHandler } from 'express'
 import cookieParser from 'cookie-parser'
 import dotenv from 'dotenv'
 
@@ -8,7 +8,6 @@ import {
   getWebBuildFolder,
   instantiateLogger,
   loadAppStreamConfig,
-  ProtocolType,
   ReturnCode,
   setProcessVariables,
   setupFolders,
@@ -28,15 +27,6 @@ instantiateLogger()
 if (verifyEnvVariables()) process.exit(ReturnCode.InvalidEnv)
 
 const app = express()
-
-const { PROTOCOL } = process.env
-
-export const cookieOptions: CookieOptions = {
-  secure: PROTOCOL === ProtocolType.HTTPS,
-  httpOnly: true,
-  sameSite: PROTOCOL === ProtocolType.HTTPS ? 'none' : undefined,
-  maxAge: 24 * 60 * 60 * 1000 // 24 hours
-}
 
 const onError: ErrorRequestHandler = (err, req, res, next) => {
   console.error(err.stack)

--- a/api/src/routes/web/web.ts
+++ b/api/src/routes/web/web.ts
@@ -14,7 +14,10 @@ webRouter.get('/', async (req, res) => {
   } catch (_) {
     response = '<html><head></head><body>Web Build is not present</body></html>'
   } finally {
-    const codeToInject = `<script>document.cookie = 'XSRF-TOKEN=${generateCSRFToken()}; Max-Age=86400; SameSite=Strict; Path=/;'</script>`
+    const { ALLOWED_DOMAIN } = process.env
+    const allowedDomain = ALLOWED_DOMAIN?.trim()
+    const domain = allowedDomain ? ` Domain=${allowedDomain};` : ''
+    const codeToInject = `<script>document.cookie = 'XSRF-TOKEN=${generateCSRFToken()};${domain} Max-Age=86400; SameSite=Strict; Path=/;'</script>`
     const injectedContent = response?.replace(
       '</head>',
       `${codeToInject}</head>`

--- a/api/src/utils/verifyEnvVariables.ts
+++ b/api/src/utils/verifyEnvVariables.ts
@@ -267,7 +267,7 @@ const verifyRUN_TIMES = (): string[] => {
   return errors
 }
 
-const verifyExecutablePaths = () => {
+const verifyExecutablePaths = (): string[] => {
   const errors: string[] = []
   const { RUN_TIMES, SAS_PATH, NODE_PATH, PYTHON_PATH, R_PATH, MODE } =
     process.env


### PR DESCRIPTION
## Issue

Closes #299

## Intent

Need to have shared session cookies, to serve AppStream hosted on separate domain.

## Implementation

Added domain to cookies

## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] Reviewer is assigned.
