### PR TITLE
fix: update the response header of request to stp/execute routes

### DIFF
--- a/api/src/controllers/internal/Execution.ts
+++ b/api/src/controllers/internal/Execution.ts
@@ -78,6 +78,11 @@ export class ExecutionController {
 
     const logPath = path.join(session.path, 'log.log')
     const headersPath = path.join(session.path, 'stpsrv_header.txt')
+
+    if (isDebugOn(vars)) {
+      await createFile(headersPath, 'content-type: text/plain')
+    }
+
     const weboutPath = path.join(session.path, 'webout.txt')
     const tokenFile = path.join(session.path, 'reqHeaders.txt')
 

--- a/api/src/controllers/internal/Session.ts
+++ b/api/src/controllers/internal/Session.ts
@@ -50,7 +50,7 @@ export class SessionController {
     }
 
     const headersPath = path.join(session.path, 'stpsrv_header.txt')
-    await createFile(headersPath, 'Content-type: text/plain')
+    await createFile(headersPath, 'content-type: text/html; charset=utf-8')
 
     this.sessions.push(session)
     return session
@@ -94,7 +94,7 @@ export class SASSessionController extends SessionController {
     }
 
     const headersPath = path.join(session.path, 'stpsrv_header.txt')
-    await createFile(headersPath, 'Content-type: text/plain')
+    await createFile(headersPath, 'content-type: text/html; charset=utf-8')
 
     // we do not want to leave sessions running forever
     // we clean them up after a predefined period, if unused

--- a/api/src/controllers/stp.ts
+++ b/api/src/controllers/stp.ts
@@ -91,6 +91,8 @@ const execute = async (
       }
     )
 
+    req.res?.header(httpHeaders)
+
     if (result instanceof Buffer) {
       ;(req as any).sasHeaders = httpHeaders
     }


### PR DESCRIPTION
## Issue

closes #322 

## Intent

update default response headers as:

* no-debug -> content-type: text/html; charset=utf-8
* debug -> content-type: text/plain

## Implementation

* updated default header when creating session to `content-type: text/html; charset=utf-8`
* if debug is true  update to `content-type: text/plain`
* previously we weren't setting the response header. Now set response headers returned from execution controller

## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] Reviewer is assigned.
