### PR TITLE
fix: non sas programs shouldn't use sas session folder

### DIFF
--- a/api/src/controllers/internal/Session.ts
+++ b/api/src/controllers/internal/Session.ts
@@ -206,12 +206,15 @@ ${autoExecContent}`
 export const getSessionController = (
   runTime: RunTimeType
 ): SessionController => {
-  if (process.sessionController) return process.sessionController
+  if (runTime === RunTimeType.SAS) {
+    process.sasSessionController =
+      process.sasSessionController || new SASSessionController()
+
+    return process.sasSessionController
+  }
 
   process.sessionController =
-    runTime === RunTimeType.SAS
-      ? new SASSessionController()
-      : new SessionController()
+    process.sessionController || new SessionController()
 
   return process.sessionController
 }

--- a/api/src/types/system/process.d.ts
+++ b/api/src/types/system/process.d.ts
@@ -9,6 +9,7 @@ declare namespace NodeJS {
     logsLoc: string
     logsUUID: string
     sessionController?: import('../../controllers/internal').SessionController
+    sasSessionController?: import('../../controllers/internal').SASSessionController
     appStreamConfig: import('../').AppStreamConfig
     logger: import('@sasjs/utils/logger').Logger
     runTimes: import('../../utils').RunTimeType[]


### PR DESCRIPTION
## Issue

closes #326
closes #328


## Intent

* JS / Python / R session folders should be NEW folders, not existing SAS folders
* use `childProcess.execFile` instead of `execFileSync`.

## Implementation

* introduced a new process variable to hold sas session controller

## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] Reviewer is assigned.
