### PR TITLE
fix: stringify json file

### DIFF
--- a/web/src/containers/Studio/internal/hooks/useEditor.ts
+++ b/web/src/containers/Studio/internal/hooks/useEditor.ts
@@ -261,8 +261,10 @@ const useEditor = ({
       axios
         .get(`/SASjsApi/drive/file?_filePath=${selectedFilePath}`)
         .then((res: any) => {
-          setPrevFileContent(res.data)
-          setFileContent(res.data)
+          const content =
+            typeof res.data === 'object' ? JSON.stringify(res.data) : res.data
+          setPrevFileContent(content)
+          setFileContent(content)
         })
         .catch((err) => {
           setModalTitle('Abort')


### PR DESCRIPTION
## Issue

closes #331

## Intent

* when API sends a JSON file in response, It's treated as a JSON object on the frontend. So, stringify the response data before setting it to file content.


## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] Reviewer is assigned.
