### PR TITLE
feat: add new env config DB_TYPE

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,9 @@ CA_ROOT=fullchain.pem (optional)
 ## ENV variables required for MODE: `server`
 DB_CONNECT=mongodb+srv://<DB_USERNAME>:<DB_PASSWORD>@<CLUSTER>/<DB_NAME>?retryWrites=true&w=majority
 
+# options: [mongodb|cosmos_mongodb] default: mongodb
+DB_TYPE=
+
 # AUTH_PROVIDERS options: [ldap] default: ``
 AUTH_PROVIDERS=
 

--- a/api/.env.example
+++ b/api/.env.example
@@ -14,6 +14,7 @@ HELMET_CSP_CONFIG_PATH=./csp.config.json if omitted HELMET default will be used
 HELMET_COEP=[true|false] if omitted HELMET default will be used
 
 DB_CONNECT=mongodb+srv://<DB_USERNAME>:<DB_PASSWORD>@<CLUSTER>/<DB_NAME>?retryWrites=true&w=majority
+DB_TYPE=[mongodb|cosmos_mongodb] default considered as mongodb
 
 AUTH_PROVIDERS=[ldap]
 

--- a/api/src/app-modules/configureExpressSession.ts
+++ b/api/src/app-modules/configureExpressSession.ts
@@ -13,17 +13,15 @@ export const configureExpressSession = (app: Express) => {
 
     if (process.env.NODE_ENV !== 'test') {
       if (DB_TYPE === DatabaseType.COSMOS_MONGODB) {
-        // COSMOS DB requires specific connection options (compatibility mode) 
+        // COSMOS DB requires specific connection options (compatibility mode)
         // See: https://www.npmjs.com/package/connect-mongo#set-the-compatibility-mode
         store = MongoStore.create({
           client: mongoose.connection!.getClient() as any,
-          collectionName: 'sessions',
           autoRemove: 'interval'
         })
       } else {
         store = MongoStore.create({
-          client: mongoose.connection!.getClient() as any,
-          collectionName: 'sessions'
+          client: mongoose.connection!.getClient() as any
         })
       }
     }

--- a/api/src/app-modules/configureExpressSession.ts
+++ b/api/src/app-modules/configureExpressSession.ts
@@ -3,19 +3,27 @@ import mongoose from 'mongoose'
 import session from 'express-session'
 import MongoStore from 'connect-mongo'
 
-import { ModeType, ProtocolType } from '../utils'
+import { DatabaseType, ModeType, ProtocolType } from '../utils'
 
 export const configureExpressSession = (app: Express) => {
-  const { MODE } = process.env
+  const { MODE, DB_TYPE } = process.env
 
   if (MODE === ModeType.Server) {
     let store: MongoStore | undefined
 
     if (process.env.NODE_ENV !== 'test') {
-      store = MongoStore.create({
-        client: mongoose.connection!.getClient() as any,
-        collectionName: 'sessions'
-      })
+      if (DB_TYPE === DatabaseType.COSMOS_MONGODB) {
+        store = MongoStore.create({
+          client: mongoose.connection!.getClient() as any,
+          collectionName: 'sessions',
+          autoRemove: 'interval'
+        })
+      } else {
+        store = MongoStore.create({
+          client: mongoose.connection!.getClient() as any,
+          collectionName: 'sessions'
+        })
+      }
     }
 
     const { PROTOCOL, ALLOWED_DOMAIN } = process.env

--- a/api/src/app-modules/configureExpressSession.ts
+++ b/api/src/app-modules/configureExpressSession.ts
@@ -13,6 +13,8 @@ export const configureExpressSession = (app: Express) => {
 
     if (process.env.NODE_ENV !== 'test') {
       if (DB_TYPE === DatabaseType.COSMOS_MONGODB) {
+        // COSMOS DB requires specific connection options (compatibility mode) 
+        // See: https://www.npmjs.com/package/connect-mongo#set-the-compatibility-mode
         store = MongoStore.create({
           client: mongoose.connection!.getClient() as any,
           collectionName: 'sessions',

--- a/api/src/utils/verifyEnvVariables.ts
+++ b/api/src/utils/verifyEnvVariables.ts
@@ -47,6 +47,11 @@ export enum ReturnCode {
   InvalidEnv
 }
 
+export enum DatabaseType {
+  MONGO = 'mongodb',
+  COSMOS_MONGODB = 'cosmos_mongodb'
+}
+
 export const verifyEnvVariables = (): ReturnCode => {
   const errors: string[] = []
 
@@ -69,6 +74,8 @@ export const verifyEnvVariables = (): ReturnCode => {
   errors.push(...verifyExecutablePaths())
 
   errors.push(...verifyLDAPVariables())
+
+  errors.push(...verifyDbType())
 
   if (errors.length) {
     process.logger?.error(
@@ -342,11 +349,30 @@ const verifyLDAPVariables = () => {
   return errors
 }
 
+const verifyDbType = () => {
+  const errors: string[] = []
+
+  const { MODE, DB_TYPE } = process.env
+
+  if (MODE === ModeType.Server) {
+    if (DB_TYPE) {
+      const dbTypes = Object.values(DatabaseType)
+      if (!dbTypes.includes(DB_TYPE as DatabaseType))
+        errors.push(`- DB_TYPE '${DB_TYPE}'\n - valid options ${dbTypes}`)
+    } else {
+      process.env.DB_TYPE = DEFAULTS.DB_TYPE
+    }
+  }
+
+  return errors
+}
+
 const DEFAULTS = {
   MODE: ModeType.Desktop,
   PROTOCOL: ProtocolType.HTTP,
   PORT: '5000',
   HELMET_COEP: HelmetCoepType.TRUE,
   LOG_FORMAT_MORGAN: LOG_FORMAT_MORGANType.Common,
-  RUN_TIMES: RunTimeType.SAS
+  RUN_TIMES: RunTimeType.SAS,
+  DB_TYPE: DatabaseType.MONGO
 }


### PR DESCRIPTION
## Issue

closes #399

## Intent

* fix: when using  Microsoft azure's cosmos MongoDB, it throws an error on configuring express session

## Implementation

* added a new env variable DB_TYPE that is checked before creating a MongoStore for storing sessions.

## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] Reviewer is assigned.
