### PR TITLE
feat: option to reset admin password on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,19 @@ MAX_WRONG_ATTEMPTS_BY_IP_PER_DAY = <number> default: 100;
 # Once a successful login is attempted, it resets
 MAX_CONSECUTIVE_FAILS_BY_USERNAME_AND_IP = <number> default: 10;
 
+# Name of the admin user that will be created on startup if not exists already
+# Default is `secretuser`
+ADMIN_USERNAME=secretuser
+
+# Temporary password for the ADMIN_USERNAME, which is in place until the first login
+# Default is `secretpassword`
+ADMIN_PASSWORD_INITIAL=secretpassword
+
+# Specify whether app has to reset the ADMIN_USERNAME's password or not
+# Default is NO. Possible options are YES and NO
+# If ADMIN_PASSWORD_RESET is YES then the ADMIN_USERNAME will be prompted to change the password from ADMIN_PASSWORD_INITIAL on their next login. This will repeat on every server restart, unless the option is removed / set to NO.
+ADMIN_PASSWORD_RESET=NO
+
 # LOG_FORMAT_MORGAN options: [combined|common|dev|short|tiny] default: `common`
 # Docs: https://www.npmjs.com/package/morgan#predefined-formats
 LOG_FORMAT_MORGAN=

--- a/api/.env.example
+++ b/api/.env.example
@@ -30,6 +30,10 @@ MAX_WRONG_ATTEMPTS_BY_IP_PER_DAY=100
 #default value is 10
 MAX_CONSECUTIVE_FAILS_BY_USERNAME_AND_IP=10
 
+ADMIN_USERNAME=secretuser
+ADMIN_PASSWORD_INITIAL=secretpassword
+ADMIN_PASSWORD_RESET=NO
+
 RUN_TIMES=[sas,js,py | js,py | sas | sas,js] default considered as sas
 SAS_PATH=/opt/sas/sas9/SASHome/SASFoundation/9.4/sas
 NODE_PATH=~/.nvm/versions/node/v16.14.0/bin/node


### PR DESCRIPTION
## Issue

closes #348

## Intent

* add the option to reset admin password on app restart
* make initial admin username and password configurable

## Implementation

* introduced 3 new env variables for configuration of initial admin user

## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] Reviewer is assigned.
