### PR TITLE
fix: applying nologo only for sas.exe

### DIFF
--- a/api/src/controllers/internal/Session.ts
+++ b/api/src/controllers/internal/Session.ts
@@ -134,7 +134,7 @@ ${autoExecContent}`
       session.path,
       '-AUTOEXEC',
       autoExecPath,
-      isWindows() ? '-nologo' : '',
+      process.sasLoc!.endsWith('sas.exe') ? '-nologo' : '',
       process.sasLoc!.endsWith('sas.exe') ? '-nosplash' : '',
       process.sasLoc!.endsWith('sas.exe') ? '-icon' : '',
       process.sasLoc!.endsWith('sas.exe') ? '-nodms' : '',


### PR DESCRIPTION


## Issue

Closes #352

## Intent

Apply -nologo option only for sas.exe executable

## Implementation

Tested SAS_PATH for 'sas.exe' to make option apply only in this case

## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] Reviewer is assigned.
