### PR TITLE
fix: use RateLimiterMemory instead of RateLimiterMongo

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ MAX_WRONG_ATTEMPTS_BY_IP_PER_DAY = <number> default: 100;
 
 
 # After this, access is blocked for an hour
-# Store number for 90 days since first fail
+# Store number for 24 days since first fail
 # Once a successful login is attempted, it resets
 MAX_CONSECUTIVE_FAILS_BY_USERNAME_AND_IP = <number> default: 10;
 


### PR DESCRIPTION
## Issue

animir/node-rate-limiter-flexible#206

## Intent

Using Microsoft Azure's CosmosDB for MongoDB is breaking the server due to some issues in `RateLimiterMongo` from `node-rate-limiter-flexible`. So, replaced `RateLimiterMongo` with `RateLimiterMemory`.

## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] Reviewer is assigned.
