### PR TITLE
fix(log-separator): log separator should always wrap log

### DIFF
--- a/api/src/controllers/internal/Execution.ts
+++ b/api/src/controllers/internal/Execution.ts
@@ -128,6 +128,7 @@ export class ExecutionController {
     // INFO: webout can be a Buffer, that is why it's length should be checked to determine if it is empty
     if (webout && webout.length !== 0) resultParts.push(webout)
 
+    // INFO: log separator wraps the log from the beginning and the end
     resultParts.push(process.logsUUID)
     resultParts.push(log)
     resultParts.push(process.logsUUID)

--- a/api/src/controllers/internal/Execution.ts
+++ b/api/src/controllers/internal/Execution.ts
@@ -130,6 +130,7 @@ export class ExecutionController {
 
     resultParts.push(process.logsUUID)
     resultParts.push(log)
+    resultParts.push(process.logsUUID)
 
     if (includePrintOutput && runTime === RunTimeType.SAS) {
       const printOutputPath = path.join(session.path, 'output.lst')
@@ -137,10 +138,7 @@ export class ExecutionController {
         ? await readFile(printOutputPath)
         : ''
 
-      if (printOutput) {
-        resultParts.push(process.logsUUID)
-        resultParts.push(printOutput)
-      }
+      if (printOutput) resultParts.push(printOutput)
     }
 
     return {

--- a/api/src/controllers/internal/Session.ts
+++ b/api/src/controllers/internal/Session.ts
@@ -190,17 +190,20 @@ ${autoExecContent}`
   }
 
   private scheduleSessionDestroy(session: Session) {
-    setTimeout(async () => {
-      if (session.inUse) {
-        // adding 10 more minutes
-        const newDeathTimeStamp = parseInt(session.deathTimeStamp) + 10 * 1000
-        session.deathTimeStamp = newDeathTimeStamp.toString()
+    setTimeout(
+      async () => {
+        if (session.inUse) {
+          // adding 10 more minutes
+          const newDeathTimeStamp = parseInt(session.deathTimeStamp) + 10 * 1000
+          session.deathTimeStamp = newDeathTimeStamp.toString()
 
-        this.scheduleSessionDestroy(session)
-      } else {
-        await this.deleteSession(session)
-      }
-    }, parseInt(session.deathTimeStamp) - new Date().getTime() - 100)
+          this.scheduleSessionDestroy(session)
+        } else {
+          await this.deleteSession(session)
+        }
+      },
+      parseInt(session.deathTimeStamp) - new Date().getTime() - 100
+    )
   }
 }
 

--- a/web/src/components/snackbar.tsx
+++ b/web/src/components/snackbar.tsx
@@ -3,12 +3,11 @@ import Snackbar from '@mui/material/Snackbar'
 import MuiAlert, { AlertProps } from '@mui/material/Alert'
 import Slide, { SlideProps } from '@mui/material/Slide'
 
-const Alert = React.forwardRef<HTMLDivElement, AlertProps>(function Alert(
-  props,
-  ref
-) {
-  return <MuiAlert elevation={6} ref={ref} variant="filled" {...props} />
-})
+const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
+  function Alert(props, ref) {
+    return <MuiAlert elevation={6} ref={ref} variant="filled" {...props} />
+  }
+)
 
 const Transition = (props: SlideProps) => {
   return <Slide {...props} direction="up" />

--- a/web/src/containers/Studio/internal/components/log/log.module.css
+++ b/web/src/containers/Studio/internal/components/log/log.module.css
@@ -7,8 +7,10 @@
   border: none;
   outline: none;
   transition: 0.4s;
-  box-shadow: rgba(0, 0, 0, 0.2) 0px 2px 1px -1px,
-    rgba(0, 0, 0, 0.14) 0px 1px 1px 0px, rgba(0, 0, 0, 0.12) 0px 1px 3px 0px;
+  box-shadow:
+    rgba(0, 0, 0, 0.2) 0px 2px 1px -1px,
+    rgba(0, 0, 0, 0.14) 0px 1px 1px 0px,
+    rgba(0, 0, 0, 0.12) 0px 1px 3px 0px;
 }
 
 .ChunkDetails {

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />


### PR DESCRIPTION
## Issue

The response body can contain multiple logs and this is why log should always be wrapped from the beginning and the end.

## Intent

- Improve response body.

## Implementation

- Wrapped log with log separator.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
- [x] All CI checks are green.
- [ ] Reviewer is assigned.
