### PR TITLE
fix: add _debug as optional query param in swagger apis for  stp/execute

### DIFF
--- a/api/public/swagger.yaml
+++ b/api/public/swagger.yaml
@@ -1806,7 +1806,7 @@ paths:
                         type: string
                     example: /Projects/myApp/some/program
                 -
-                    description: 'Optional query param for setting debug mode (returns the session log in the response body'
+                    description: 'Optional query param for setting debug mode (returns the session log in the response body)'
                     in: query
                     name: _debug
                     required: false

--- a/api/public/swagger.yaml
+++ b/api/public/swagger.yaml
@@ -1798,7 +1798,7 @@ paths:
                     bearerAuth: []
             parameters:
                 -
-                    description: 'Location of code in SASjs Drive'
+                    description: 'Location of the Stored Program in SASjs Drive'
                     in: query
                     name: _program
                     required: true
@@ -1806,7 +1806,7 @@ paths:
                         type: string
                     example: /Projects/myApp/some/program
                 -
-                    description: 'Optional query param for setting debug mode'
+                    description: 'Optional query param for setting debug mode (returns the session log in the response body'
                     in: query
                     name: _debug
                     required: false

--- a/api/public/swagger.yaml
+++ b/api/public/swagger.yaml
@@ -792,7 +792,7 @@ paths:
                                     - {type: string}
                                     - {type: string, format: byte}
             description: 'Execute Code on the Specified Runtime'
-            summary: 'Run Code and Return Webout Content and Log'
+            summary: "Run Code and Return Webout Content, Log and Print output\nThe order of returned parts of the payload is:\n1. Webout (if present)\n2. Logs UUID (used as separator)\n3. Log\n4. Logs UUID (used as separator)\n5. Print (if present and if the runtime is SAS)\nPlease see"
             tags:
                 - Code
             security:
@@ -1805,6 +1805,15 @@ paths:
                     schema:
                         type: string
                     example: /Projects/myApp/some/program
+                -
+                    description: 'Optional query param for setting debug mode'
+                    in: query
+                    name: _debug
+                    required: false
+                    schema:
+                        format: double
+                        type: number
+                    example: 131
         post:
             operationId: ExecutePostRequest
             responses:

--- a/api/src/controllers/stp.ts
+++ b/api/src/controllers/stp.ts
@@ -24,7 +24,7 @@ export class STPController {
   /**
    * Trigger a Stored Program using the _program URL parameter.
    *
-   * Accepts additional URL parameters (converted to session variables) 
+   * Accepts additional URL parameters (converted to session variables)
    * and file uploads.  For more details, see docs:
    *
    * https://server.sasjs.io/storedprograms

--- a/api/src/controllers/stp.ts
+++ b/api/src/controllers/stp.ts
@@ -24,13 +24,14 @@ export class STPController {
   /**
    * Trigger a Stored Program using the _program URL parameter.
    *
-   * Accepts URL parameters and file uploads.  For more details, see docs:
+   * Accepts additional URL parameters (converted to session variables) 
+   * and file uploads.  For more details, see docs:
    *
    * https://server.sasjs.io/storedprograms
    *
    * @summary Execute a Stored Program, returns _webout and (optionally) log.
    * @param _program Location of code in SASjs Drive
-   * @param _debug Optional query param for setting debug mode
+   * @param _debug Optional query param for setting debug mode, which will return the session log.
    * @example _program "/Projects/myApp/some/program"
    * @example _debug 131
    */

--- a/api/src/controllers/stp.ts
+++ b/api/src/controllers/stp.ts
@@ -7,6 +7,7 @@ import {
   getRunTimeAndFilePath
 } from '../utils'
 import { MulterFile } from '../types/Upload'
+import { debug } from 'console'
 
 interface ExecutePostRequestPayload {
   /**
@@ -29,14 +30,23 @@ export class STPController {
    *
    * @summary Execute a Stored Program, returns _webout and (optionally) log.
    * @param _program Location of code in SASjs Drive
+   * @param _debug Optional query param for setting debug mode
    * @example _program "/Projects/myApp/some/program"
+   * @example _debug 131
    */
   @Get('/execute')
   public async executeGetRequest(
     @Request() request: express.Request,
-    @Query() _program: string
+    @Query() _program: string,
+    @Query() _debug?: number
   ): Promise<string | Buffer> {
-    const vars = request.query as ExecutionVars
+    let vars = request.query as ExecutionVars
+    if (_debug) {
+      vars = {
+        ...vars,
+        _debug
+      }
+    }
 
     return execute(request, _program, vars)
   }

--- a/api/src/routes/api/stp.ts
+++ b/api/src/routes/api/stp.ts
@@ -13,7 +13,11 @@ stpRouter.get('/execute', async (req, res) => {
   if (error) return res.status(400).send(error.details[0].message)
 
   try {
-    const response = await controller.executeGetRequest(req, query._program)
+    const response = await controller.executeGetRequest(
+      req,
+      query._program,
+      query._debug
+    )
 
     if (response instanceof Buffer) {
       res.writeHead(200, (req as any).sasHeaders)

--- a/api/src/utils/validation.ts
+++ b/api/src/utils/validation.ts
@@ -180,7 +180,8 @@ export const runCodeValidation = (data: any): Joi.ValidationResult =>
 
 export const executeProgramRawValidation = (data: any): Joi.ValidationResult =>
   Joi.object({
-    _program: Joi.string().required()
+    _program: Joi.string().required(),
+    _debug: Joi.number()
   })
     .pattern(/^/, Joi.alternatives(Joi.string(), Joi.number()))
     .validate(data)


### PR DESCRIPTION
## Issue

* swagger APIs didn't have the option to pass _debug as a query param

## Intent

* update swagger docs to include _debug as optional query param fof\r GET stp/execute API endpoint

![image](https://github.com/sasjs/server/assets/82647447/ef9e1842-0f5d-442c-bb74-2474cf3a3b97)


## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] Reviewer is assigned.
