### PR TITLE
fix: enable embedded LFs in JS STP vars

### DIFF
--- a/api/src/controllers/internal/createJSProgram.ts
+++ b/api/src/controllers/internal/createJSProgram.ts
@@ -15,7 +15,7 @@ export const createJSProgram = async (
 ) => {
   const varStatments = Object.keys(vars).reduce(
     (computed: string, key: string) =>
-      `${computed}const ${key} = '${vars[key]}';\n`,
+      `${computed}const ${key} = \`${vars[key]}\`;\n`,
     ''
   )
 

--- a/api/src/utils/upload.ts
+++ b/api/src/utils/upload.ts
@@ -51,9 +51,8 @@ export const generateFileUploadSasCode = async (
   let fileCount = 0
   const uploadedFiles: UploadedFiles[] = []
 
-  const sasSessionFolderList: string[] = await listFilesInFolder(
-    sasSessionFolder
-  )
+  const sasSessionFolderList: string[] =
+    await listFilesInFolder(sasSessionFolder)
   sasSessionFolderList.forEach((fileName) => {
     let fileCountString = fileCount < 100 ? '0' + fileCount : fileCount
     fileCountString = fileCount < 10 ? '00' + fileCount : fileCount


### PR DESCRIPTION
The aim is to avoid issues like this:

![image](https://github.com/sasjs/server/assets/4420615/c0852632-2385-4d51-a4f9-6422c74d30f6)

