### PR TITLE
fix(api): fixed env issue in MacOS executable

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -51,7 +51,7 @@
         "adm-zip": "^0.5.9",
         "axios": "0.27.2",
         "csrf": "^3.1.0",
-        "dotenv": "^10.0.0",
+        "dotenv": "^16.0.1",
         "http-headers-validation": "^0.0.1",
         "jest": "^27.0.6",
         "mongodb-memory-server": "8.11.4",
@@ -4788,12 +4788,12 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
+      "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ==",
       "dev": true,
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/duplexer2": {
@@ -15217,9 +15217,9 @@
       }
     },
     "dotenv": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
+      "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ==",
       "dev": true
     },
     "duplexer2": {

--- a/api/package.json
+++ b/api/package.json
@@ -88,7 +88,7 @@
     "adm-zip": "^0.5.9",
     "axios": "0.27.2",
     "csrf": "^3.1.0",
-    "dotenv": "^10.0.0",
+    "dotenv": "^16.0.1",
     "http-headers-validation": "^0.0.1",
     "jest": "^27.0.6",
     "mongodb-memory-server": "8.11.4",


### PR DESCRIPTION
## Issue

Closes #371 

## Intent

- Fix MacOS executable env loading issue.

## Implementation

- Added `execPath` check to `setProcessVariables` func in `api/src/utils/setProcessVariables.ts` to provide a path to the `.env` file located in the same folder with the MacOS executable.
- Updated `dotenv` package.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [x] Reviewer is assigned.
