### PR TITLE
fix: (deps) bump @sasjs/core to 4.59.7

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -8,7 +8,7 @@
       "name": "api",
       "version": "0.0.2",
       "dependencies": {
-        "@sasjs/core": "^4.40.1",
+        "@sasjs/core": "^4.59.7",
         "@sasjs/utils": "^3.5.2",
         "bcryptjs": "^2.4.3",
         "connect-mongo": "^5.1.0",
@@ -490,37 +490,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/credential-providers": {
-      "version": "3.896.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.896.0.tgz",
-      "integrity": "sha512-0hj809k7+BPq/tYF7cbTX43c7MTT1cksSwPvkRai4NZDLhsRRHMy/Op419CcdQB4d4QMl0z5+8PNzOOkh0XTCQ==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.896.0",
-        "@aws-sdk/core": "3.896.0",
-        "@aws-sdk/credential-provider-cognito-identity": "3.896.0",
-        "@aws-sdk/credential-provider-env": "3.896.0",
-        "@aws-sdk/credential-provider-http": "3.896.0",
-        "@aws-sdk/credential-provider-ini": "3.896.0",
-        "@aws-sdk/credential-provider-node": "3.896.0",
-        "@aws-sdk/credential-provider-process": "3.896.0",
-        "@aws-sdk/credential-provider-sso": "3.896.0",
-        "@aws-sdk/credential-provider-web-identity": "3.896.0",
-        "@aws-sdk/nested-clients": "3.896.0",
-        "@aws-sdk/types": "3.893.0",
-        "@smithy/config-resolver": "^4.2.2",
-        "@smithy/core": "^3.12.0",
-        "@smithy/credential-provider-imds": "^4.1.2",
-        "@smithy/node-config-provider": "^4.2.2",
-        "@smithy/property-provider": "^4.1.1",
-        "@smithy/types": "^4.5.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@aws-sdk/middleware-host-header": {
       "version": "3.893.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.893.0.tgz",
@@ -813,6 +782,7 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -1777,9 +1747,9 @@
       }
     },
     "node_modules/@sasjs/core": {
-      "version": "4.59.5",
-      "resolved": "https://registry.npmjs.org/@sasjs/core/-/core-4.59.5.tgz",
-      "integrity": "sha512-PAPinHjuFi3P/MxkZHGSF0iLWoBFnpxon7/SshHPcBRmSQwmFOvh9X8xdE8ZClqY9XDOwFZ6sqeOQ7GYZliLfw==",
+      "version": "4.59.7",
+      "resolved": "https://registry.npmjs.org/@sasjs/core/-/core-4.59.7.tgz",
+      "integrity": "sha512-1sndZfmAhp0qAE+bprbFCCHBgTtGVMZ5y5gA830QhyLJPdjJ0IKTEYidR7J5563l72YMP5FWwehCOjqRXjKOaw==",
       "license": "MIT"
     },
     "node_modules/@sasjs/utils": {
@@ -2905,6 +2875,7 @@
       "integrity": "sha512-Crp6WY9aTYP3qPi2wGDo9iUe/rceX01UMhnF1jmwDcKCFM6cx7YhGP/Mpr3y9AASpfHixIG0E6azCcL5OcDHsQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.33",
@@ -3068,6 +3039,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.17.tgz",
       "integrity": "sha512-gfehUI8N1z92kygssiuWvLiwcbOB3IRktR6hTDgJlXMYh5OvkPSRmgfoBUmfZt+vhwJtX7v1Yw4KvvAf7c5QKQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3187,7 +3159,6 @@
       "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
       "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/webidl-conversions": "*"
       }
@@ -3871,6 +3842,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.3",
         "caniuse-lite": "^1.0.30001741",
@@ -5257,6 +5229,7 @@
       "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.2.tgz",
       "integrity": "sha512-SZjssGQC7TzTs9rpPDuUrR23GNZ9+2+IkA/+IJWmvQilTr5OSliEHGF+D9scbIpdC6yGtTI0/VhaHoVes2AN/A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cookie": "0.7.2",
         "cookie-signature": "1.0.7",
@@ -6868,6 +6841,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -8145,7 +8119,6 @@
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.20.0.tgz",
       "integrity": "sha512-Tl6MEIU3K4Rq3TSHd+sZQqRBoGlFsOgNrH5ltAcFBV62Re3Fd+FcaVf8uSEQFOJ51SDowDVttBTONMfoYWrWlQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@mongodb-js/saslprep": "^1.3.0",
         "bson": "^6.10.4",
@@ -8192,7 +8165,6 @@
       "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.2.tgz",
       "integrity": "sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@types/whatwg-url": "^11.0.2",
         "whatwg-url": "^14.1.0 || ^13.0.0"
@@ -8340,7 +8312,6 @@
       "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.4.tgz",
       "integrity": "sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=16.20.1"
       }
@@ -10250,6 +10221,7 @@
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
       "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ip-address": "^10.0.1",
         "smart-buffer": "^4.2.0"
@@ -10772,7 +10744,6 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
       "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "punycode": "^2.3.1"
       },
@@ -10891,6 +10862,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -11116,6 +11088,7 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11418,7 +11391,6 @@
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
       "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tr46": "^5.1.0",
         "webidl-conversions": "^7.0.0"

--- a/api/package.json
+++ b/api/package.json
@@ -48,7 +48,7 @@
   },
   "author": "4GL Ltd",
   "dependencies": {
-    "@sasjs/core": "^4.40.1",
+    "@sasjs/core": "^4.59.7",
     "@sasjs/utils": "^3.5.2",
     "bcryptjs": "^2.4.3",
     "connect-mongo": "^5.1.0",


### PR DESCRIPTION
## Issue

The @sasjs/core package is in need of a bump from 4.40.1 to 4.59.7.

## Intent

Include the latest version of @sasjs/core.

## Implementation

Bump the `package.json` dependencies for @sasjs/core.
Submit `npm i` to automatically update the `package-lock.json`

## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] Reviewer is assigned.
