### PR TITLE
chore: pin axios versions

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -49,7 +49,7 @@
         "@types/swagger-ui-express": "^4.1.3",
         "@types/unzipper": "^0.10.5",
         "adm-zip": "^0.5.9",
-        "axios": "^1.12.2",
+        "axios": "1.12.2",
         "csrf": "^3.1.0",
         "dotenv": "^16.0.1",
         "http-headers-validation": "^0.0.1",
@@ -3588,11 +3588,10 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
-      "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.4",

--- a/api/package.json
+++ b/api/package.json
@@ -84,7 +84,7 @@
     "@types/swagger-ui-express": "^4.1.3",
     "@types/unzipper": "^0.10.5",
     "adm-zip": "^0.5.9",
-    "axios": "^1.12.2",
+    "axios": "1.12.2",
     "csrf": "^3.1.0",
     "dotenv": "^16.0.1",
     "http-headers-validation": "^0.0.1",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -20,7 +20,7 @@
         "@types/jest": "^26.0.24",
         "@types/node": "^12.20.28",
         "@types/react": "^17.0.27",
-        "axios": "^1.12.2",
+        "axios": "1.12.2",
         "monaco-editor": "^0.33.0",
         "react": "^17.0.2",
         "react-copy-to-clipboard": "^5.1.0",
@@ -4334,7 +4334,6 @@
       "version": "1.12.2",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
       "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
-      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.4",

--- a/web/package.json
+++ b/web/package.json
@@ -19,7 +19,7 @@
     "@types/jest": "^26.0.24",
     "@types/node": "^12.20.28",
     "@types/react": "^17.0.27",
-    "axios": "^1.12.2",
+    "axios": "1.12.2",
     "monaco-editor": "^0.33.0",
     "react": "^17.0.2",
     "react-copy-to-clipboard": "^5.1.0",


### PR DESCRIPTION
## Intent

Pin the `axios` version to prevent `npm install` on developer machines from pulling unwanted versions. Workflow actions are protected with `npm ci`.

## Implementation

Installed axios with `--save-exact` flag.