### PR TITLE
Issue 390

### DIFF
--- a/api/src/controllers/internal/Execution.ts
+++ b/api/src/controllers/internal/Execution.ts
@@ -120,7 +120,16 @@ export class ExecutionController {
       : ''
 
     // it should be deleted by scheduleSessionDestroy
-    session.state = SessionState.completed
+    //
+    // Guarded: for JS/PY/R, processProgram sets state to `failed` itself
+    // (without throwing) when the interpreter process exits non-zero - if
+    // we unconditionally set `completed` here we'd silently overwrite that,
+    // and anything downstream inspecting session.state (e.g.
+    // scheduleSessionDestroy's expiresAfterMins branch in Session.ts) would
+    // see a crashed session mis-reported as successful.
+    if ((session.state as SessionState) !== SessionState.failed) {
+      session.state = SessionState.completed
+    }
 
     const resultParts = []
 

--- a/api/src/controllers/internal/spec/Execution.spec.ts
+++ b/api/src/controllers/internal/spec/Execution.spec.ts
@@ -1,0 +1,84 @@
+import path from 'path'
+import os from 'os'
+import { deleteFolder, generateTimestamp } from '@sasjs/utils'
+import * as ProcessProgramModule from '../processProgram'
+import { ExecutionController } from '../Execution'
+import { Session, SessionState, PreProgramVars } from '../../../types'
+import { RunTimeType } from '../../../utils'
+
+// Regression coverage: for JS/PY/R, processProgram sets session.state to
+// `failed` itself (without throwing) on a non-zero interpreter exit.
+// ExecutionController.executeProgram used to unconditionally overwrite
+// that back to `completed` right after processProgram returned, silently
+// losing the failure for anything downstream that inspects session.state.
+
+const preProgramVariables: PreProgramVars = {
+  username: 'testUser',
+  userId: 1,
+  displayName: 'Test User',
+  serverUrl: 'http://localhost:5000',
+  httpHeaders: []
+}
+
+describe('ExecutionController.executeProgram (JS/PY/R failure path)', () => {
+  let session: Session
+
+  beforeEach(() => {
+    const sessionId = `test-session-${generateTimestamp()}`
+    session = {
+      id: sessionId,
+      state: SessionState.pending,
+      creationTimeStamp: '0',
+      deathTimeStamp: '0',
+      path: path.join(os.tmpdir(), sessionId)
+    }
+  })
+
+  afterEach(async () => {
+    jest.restoreAllMocks()
+    await deleteFolder(session.path)
+  })
+
+  it('does not overwrite a failed session state back to completed', async () => {
+    // mirrors processProgram's real JS/PY/R branch on a non-zero exit:
+    // it sets state/failureReason itself and resolves - it does not throw
+    jest
+      .spyOn(ProcessProgramModule, 'processProgram')
+      .mockImplementation(async () => {
+        session.state = SessionState.failed
+        session.failureReason = 'Error: process exited with code 1'
+      })
+
+    const controller = new ExecutionController()
+
+    await controller.executeProgram({
+      program: 'throw new Error("boom")',
+      preProgramVariables,
+      vars: {},
+      session,
+      runTime: RunTimeType.JS
+    })
+
+    expect(session.state).toBe(SessionState.failed)
+  })
+
+  it('still marks a genuinely successful session as completed', async () => {
+    jest
+      .spyOn(ProcessProgramModule, 'processProgram')
+      .mockImplementation(async () => {
+        session.state = SessionState.completed
+      })
+
+    const controller = new ExecutionController()
+
+    await controller.executeProgram({
+      program: 'console.log("hello")',
+      preProgramVariables,
+      vars: {},
+      session,
+      runTime: RunTimeType.JS
+    })
+
+    expect(session.state).toBe(SessionState.completed)
+  })
+})

--- a/api/src/routes/api/spec/drive.spec.ts
+++ b/api/src/routes/api/spec/drive.spec.ts
@@ -28,6 +28,15 @@ jest
   .spyOn(fileUtilModules, 'getUploadsFolder')
   .mockImplementation(() => path.join(tmpFolder, 'uploads'))
 
+// getFilesFolder() resolves via getSasjsDriveFolder()/process.driveLoc, a
+// separate root from getSasjsRootFolder()/process.sasjsRoot above - without
+// this, every test in this file that creates content under the drive (e.g.
+// 'level1', 'my/path/...') writes into the real, shared sasjs_root/drive
+// instead of this run's isolated tmpFolder, leaking state into later runs.
+jest
+  .spyOn(fileUtilModules, 'getFilesFolder')
+  .mockImplementation(() => path.join(tmpFolder, 'drive', 'files'))
+
 import appPromise from '../../../app'
 import {
   UserController,


### PR DESCRIPTION
## Issue

Closes #390

## Intent

Two small, independent fixes bundled on this branch:

1. Stop `ExecutionController` from silently discarding a failed JS/PY/R
   session's state.
2. Stop `drive.spec.ts` from leaking real files into the shared
   `sasjs_root` directory, which was causing spurious failures on
   subsequent local test runs.

## Implementation

### 1. JS/PY/R session state overwrite

For the JS/PY/R runtimes, `processProgram` sets `session.state = failed`
(with `session.failureReason`) itself when the spawned interpreter process
exits non-zero — without throwing:

```ts
// processProgram.ts
.catch((err) => {
  session.state = SessionState.failed
  session.failureReason = err.toString()
  ...
})
```

Immediately after `processProgram` returns, `Execution.ts` unconditionally
overwrote that state:

```ts
// Execution.ts (before)
session.state = SessionState.completed
```

So a crashed JS/PY/R session had its `failed` state silently stomped back
to `completed` before ever being inspected or cleaned up. The client-visible
HTTP error response was unaffected (that's built from the log/webout files,
not `session.state`), but anything downstream inspecting the session object
itself — e.g. `scheduleSessionDestroy`'s `expiresAfterMins` branch in
`Session.ts` — would see a crashed session mis-reported as successful.

**Fix** (`Execution.ts:130-132`): guard the assignment so a `failed` state
is never overwritten. No effect on SAS, which manages its own state via a
separate spawned-process lifecycle.

**Tests** (`Execution.spec.ts`, new): covers both the failure case (state
stays `failed`) and the success case (state still becomes `completed`), so
neither direction regresses.

### 2. `drive.spec.ts` leaking into the real `sasjs_root`

`drive.spec.ts` already isolates itself into a unique, timestamped
`tmpFolder` for `getSasjsRootFolder()`/`getUploadsFolder()`, cleaned up via
`afterAll(() => deleteFolder(tmpFolder))`. But `getFilesFolder()` — what
nearly every test in this file actually writes to — resolves through a
separate, unmocked function (`getSasjsDriveFolder()` → `process.driveLoc`),
so every run left real files/folders (`level1`, `my/path/...`) behind in
the shared `api/sasjs_root/drive/files`. On a subsequent run this caused:
folder-listing tests seeing stale entries left by a prior run, and
file-creation tests getting `409 Conflict` against files a previous run had
already created.

**Fix**: mock `getFilesFolder()` the same way `getUploadsFolder()` already
is, so it resolves inside the same isolated `tmpFolder` and gets cleaned up
by the existing `afterAll`.

**Verification**: ran the suite twice in a row from a clean slate — both
runs pass, and the real `sasjs_root/drive` directory is never touched by
either run.

## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] Reviewer is assigned.
